### PR TITLE
Label query and scope bindings from `.typ` (with a simple Ui implementation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,27 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
-name = "alsa"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fe60779335388a88c01ac6c3be40304d1e349de3ada3b15f7808bb90fa9dce"
-dependencies = [
- "alsa-sys",
- "bitflags 2.5.0",
- "libc",
-]
-
-[[package]]
-name = "alsa-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +122,7 @@ dependencies = [
  "jni-sys",
  "libc",
  "log",
- "ndk 0.9.0",
+ "ndk",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -328,36 +307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_animation"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23aa4141df149b743e69c90244261c6372bafb70d9f115885de48a75fc28fd9b"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core",
- "bevy_derive",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_log",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
- "blake3",
- "fixedbitset 0.5.7",
- "petgraph",
- "ron",
- "serde",
- "thiserror",
- "thread_local",
- "uuid",
-]
-
-[[package]]
 name = "bevy_app"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,25 +366,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.65",
-]
-
-[[package]]
-name = "bevy_audio"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41ecf15d0aae31bdb6d2b5cc590f966451e9736ddfee634c8f1ca5af1ac4342"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_derive",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_math",
- "bevy_reflect",
- "bevy_transform",
- "bevy_utils",
- "cpal",
- "rodio",
 ]
 
 [[package]]
@@ -516,7 +446,6 @@ dependencies = [
  "bevy_time",
  "bevy_utils",
  "const-fnv1a-hash",
- "sysinfo",
 ]
 
 [[package]]
@@ -563,21 +492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_gilrs"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbad8e59470c3d5cf25aa8c48462c4cf6f0c6314538c68ab2f5cf393146f0fc2"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_input",
- "bevy_time",
- "bevy_utils",
- "gilrs",
- "thiserror",
-]
-
-[[package]]
 name = "bevy_gizmos"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,37 +524,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.65",
-]
-
-[[package]]
-name = "bevy_gltf"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7abeaf3f28afd1f8999c2169aa17b40a37ad11253cf7dd05017024b65adc6"
-dependencies = [
- "base64 0.22.1",
- "bevy_animation",
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core",
- "bevy_core_pipeline",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_math",
- "bevy_pbr",
- "bevy_reflect",
- "bevy_render",
- "bevy_scene",
- "bevy_tasks",
- "bevy_transform",
- "bevy_utils",
- "gltf",
- "percent-encoding",
- "serde",
- "serde_json",
- "smallvec",
- "thiserror",
 ]
 
 [[package]]
@@ -679,19 +562,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ddd2b23e44d3a1f8ae547cbee5b6661f8135cc456c5de206e8648789944e7a1"
 dependencies = [
  "bevy_a11y",
- "bevy_animation",
  "bevy_app",
  "bevy_asset",
- "bevy_audio",
  "bevy_color",
  "bevy_core",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
- "bevy_gilrs",
  "bevy_gizmos",
- "bevy_gltf",
  "bevy_hierarchy",
  "bevy_input",
  "bevy_log",
@@ -702,7 +581,6 @@ dependencies = [
  "bevy_render",
  "bevy_scene",
  "bevy_sprite",
- "bevy_state",
  "bevy_tasks",
  "bevy_text",
  "bevy_time",
@@ -807,7 +685,6 @@ dependencies = [
  "downcast-rs",
  "erased-serde",
  "glam",
- "petgraph",
  "serde",
  "smallvec",
  "smol_str",
@@ -935,32 +812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_state"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0959984092d56885fd3b320ea84fb816821bad6bfa3040b9d4ee850d3273233d"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_reflect",
- "bevy_state_macros",
- "bevy_utils",
-]
-
-[[package]]
-name = "bevy_state_macros"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887a98bfa268258377cd073f5bb839518d3a1cd6b96ed81418145485b69378e6"
-dependencies = [
- "bevy_macro_utils",
- "proc-macro2",
- "quote",
- "syn 2.0.65",
-]
-
-[[package]]
 name = "bevy_tasks"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +881,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_vello",
+ "bevy_vello_graphics",
  "chrono",
  "comemo",
  "dirs",
@@ -1042,6 +894,7 @@ dependencies = [
  "typst",
  "typst-assets",
  "typst-svg",
+ "typst_element",
  "ureq",
 ]
 
@@ -1116,6 +969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_vello_graphics"
+version = "0.1.0"
+source = "git+https://github.com/voxell-tech/bevy_vello_graphics#18cba862dbe94c8c3d294679402471e7f37b323c"
+dependencies = [
+ "bevy",
+ "bevy_vello",
+]
+
+[[package]]
 name = "bevy_window"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,26 +1041,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
-dependencies = [
- "bitflags 2.5.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.65",
 ]
 
 [[package]]
@@ -1355,15 +1197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,17 +1279,6 @@ checksum = "d259fe9fd78ffa05a119581d20fddb50bfba428311057b12741ffb9015123d0b"
 dependencies = [
  "quick-xml",
  "serde",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.3",
 ]
 
 [[package]]
@@ -1647,49 +1469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coreaudio-rs"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f01585027057ff5f0a5bf276174ae4c1594a2c5bde93d5f46a016d76270f5a9"
-dependencies = [
- "bindgen",
-]
-
-[[package]]
-name = "cpal"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
-dependencies = [
- "alsa",
- "core-foundation-sys",
- "coreaudio-rs",
- "dasp_sample",
- "jni",
- "js-sys",
- "libc",
- "mach2",
- "ndk 0.8.0",
- "ndk-context",
- "oboe",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows 0.54.0",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,12 +1554,6 @@ dependencies = [
  "libloading 0.8.3",
  "winapi",
 ]
-
-[[package]]
-name = "dasp_sample"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -2264,40 +2037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gilrs"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54e5e39844ab5cddaf3bbbdfdc2923a6cb34e36818b95618da4e3f26302c24c"
-dependencies = [
- "fnv",
- "gilrs-core",
- "log",
- "uuid",
- "vec_map",
-]
-
-[[package]]
-name = "gilrs-core"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c132270a155f2548e67d66e731075c336c39098afc555752f3df8f882c720e"
-dependencies = [
- "core-foundation",
- "inotify",
- "io-kit-sys",
- "js-sys",
- "libc",
- "libudev-sys",
- "log",
- "nix",
- "uuid",
- "vec_map",
- "wasm-bindgen",
- "web-sys",
- "windows 0.54.0",
-]
-
-[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,12 +2059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "glow"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,42 +2068,6 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gltf"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ce1918195723ce6ac74e80542c5a96a40c2b26162c1957a5cd70799b8cacf7"
-dependencies = [
- "byteorder",
- "gltf-json",
- "lazy_static",
- "serde_json",
-]
-
-[[package]]
-name = "gltf-derive"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14070e711538afba5d6c807edb74bcb84e5dbb9211a3bf5dea0dfab5b24f4c51"
-dependencies = [
- "inflections",
- "proc-macro2",
- "quote",
- "syn 2.0.65",
-]
-
-[[package]]
-name = "gltf-json"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6176f9d60a7eab0a877e8e96548605dedbde9190a7ae1e80bbcc1c9af03ab14"
-dependencies = [
- "gltf-derive",
- "serde",
- "serde_derive",
- "serde_json",
 ]
 
 [[package]]
@@ -2803,51 +2500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
-name = "inflections"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
-
-[[package]]
-name = "inotify"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "io-kit-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
-dependencies = [
- "core-foundation-sys",
- "mach2",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,23 +2622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lewton"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
-dependencies = [
- "byteorder",
- "ogg",
- "tinyvec",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,16 +2672,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -3109,15 +2734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "mach2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,12 +2780,6 @@ dependencies = [
  "objc",
  "paste",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3237,20 +2847,6 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.5.0",
- "jni-sys",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "thiserror",
-]
-
-[[package]]
-name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -3289,41 +2885,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
-
-[[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3350,17 +2915,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
-]
 
 [[package]]
 name = "num-integer"
@@ -3621,38 +3175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "ogg"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3771,8 +3293,6 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
  "indexmap",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -4184,17 +3704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rodio"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fceb9d127d515af1586d8d0cc601e1245bdb0af38e75c865a156290184f5b3"
-dependencies = [
- "cpal",
- "lewton",
- "thiserror",
-]
-
-[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,12 +3925,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
@@ -4649,20 +4152,6 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.30.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "windows 0.52.0",
 ]
 
 [[package]]
@@ -5086,6 +4575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "typst_element"
+version = "0.1.0"
+dependencies = [
+ "typst",
+]
+
+[[package]]
+name = "typst_vello"
+version = "0.1.0"
+
+[[package]]
 name = "unic-langid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,12 +4846,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "velato"
@@ -6030,7 +5524,7 @@ dependencies = [
  "dpi",
  "js-sys",
  "libc",
- "ndk 0.9.0",
+ "ndk",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4579,6 +4579,7 @@ name = "typst_element"
 version = "0.1.0"
 dependencies = [
  "typst",
+ "unicode-math-class",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bevy_vello_graphics = { version = "0.1.0", git = "https://github.com/voxell-tech
 # Typst dependencies
 typst = "0.11"
 comemo = "0.4" # in sync with typst
+unicode-math-class = "0.1" # in sync with typst
 
 [package]
 name = "bevy_typst"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,41 @@
-[package]
-name = "bevy_typst"
+[workspace]
+resolver = "2"
+members = ["crates/*", ]
+
+[workspace.package]
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/nixon-voxell/bevy_typst"
+readme = "README.md"
+
+[workspace.dependencies]
+# Bevy dependencies
+bevy = { version = "0.14", default-features = false }
+bevy_vello_graphics = { version = "0.1.0", git = "https://github.com/voxell-tech/bevy_vello_graphics" }
+# Typst dependencies
+typst = "0.11"
+comemo = "0.4" # in sync with typst
+
+[package]
+name = "bevy_typst"
+description = "Typst integration in Bevy."
+exclude = ["/assets/", "/.github/", "/examples/"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
 
 [dependencies]
-bevy = "0.14"
+typst_element = { version = "0.1.0", path = "crates/typst_element" }
+bevy = { workspace = true }
 bevy_vello = { version = "0.5", features = ["svg"] }
-# typst dependencies
-typst = "0.11"
+bevy_vello_graphics = { workspace = true }
+typst = { workspace = true }
 typst-svg = "0.11"
 typst-assets = { version = "0.11", features = ["fonts"], optional = true }
-comemo = "0.4" # in sync with typst
+comemo = { workspace = true }
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
 
 serde = "1"

--- a/assets/hello_world.typ
+++ b/assets/hello_world.typ
@@ -4,19 +4,11 @@
   fill: rgb("#19181A"),
 )
 #set raw(theme: "Monokai Pro.tmTheme")
-#set text(size: 48pt, fill: rgb("#FCFCFA"))
+#set text(size: 24pt, fill: rgb("#FCFCFA"))
 
-#metadata(
-  box()[#text(fill: gradient.linear(rgb("#13A8C1"), rgb("#21C0AA")))[= Typst]],
-) <typst_title>
-
-// #box()[
-//   #text(fill: gradient.linear(rgb("#13A8C1"), rgb("#21C0AA")))[= Typst]
-// ]
-
-#context {
-  query(<typst_title>).first().value
-}
+#text(
+  fill: gradient.linear(rgb("#13A8C1"), rgb("#21C0AA")),
+)[= Typst] <typst_title>
 
 Total displaced soil by glacial flow:
 

--- a/assets/simple_ui.typ
+++ b/assets/simple_ui.typ
@@ -6,47 +6,46 @@
   fill: base0,
 )
 #let icon_config = (
-  size: 48pt,
+  size: 24pt,
 )
 #(icon_config.padding = icon_config.size / 4)
 #(icon_config.inset = icon_config.padding / 2)
 #(icon_config.frame = icon_config.size + icon_config.padding)
 
 #let font_config = (
-  size: 32pt,
+  size: 16pt,
 )
 #(font_config.padding = font_config.size / 4)
 #(font_config.inset = font_config.padding / 2)
 #(font_config.frame = font_config.size + font_config.padding)
 
-#set text(size: font_config.size, fill: base8)
-
 #let gradient_title(body) = {
-  set text(size: font_config.size, fill: base8)
-  text(fill: gradient.linear(blue, green))[= #body]
+  text(size: font_config.size * 2, fill: gradient.linear(blue, green))[= #body]
 }
 
 #let frame(body) = {
+  set text(size: font_config.size, fill: base8)
   box(
     body,
-    inset: icon_config.inset * 2,
-    radius: icon_config.padding,
+    inset: font_config.inset * 2,
+    radius: font_config.padding,
     fill: base1,
   )
 }
 
 #let button(body) = {
+  set text(size: font_config.size, fill: base8)
   box(
     body,
-    inset: icon_config.inset * 2,
-    radius: icon_config.padding,
+    inset: font_config.inset * 2,
+    radius: font_config.padding,
     fill: base2,
     stroke: 2pt + base6,
   )
 }
 
 #let icon(e) = {
-  set text(size: icon_config.size)
+  set text(size: icon_config.size, fill: base8)
   box(
     align(center + horizon)[#e],
     width: icon_config.frame,
@@ -57,49 +56,50 @@
   )
 }
 
-#block(width: 1280pt, height: 720pt, inset: font_config.inset)[
-  #gradient_title("Typst")
-  // #frame[
-  //   #icon(emoji.clock.two)
-  //   #icon(emoji.cloud)
-  //   #icon(emoji.notebook)
-  // ]
+#let menu_item(top_content, bottom_content, height: 10em, width: 8em) = {
+  set text(size: font_config.size, fill: base8)
 
-  #let size = 400pt
-  #let half_size = size / 2
-  #let offset = 50pt
-  #for value in (1, 2, 3) {
-    let o = offset * value
-    place(
-      top,
-      dx: 40% - half_size + o - offset,
-      dy: 50% - half_size + o - offset,
-    )[
-      #box(
-        width: size,
-        height: size,
-        fill: rgb(base7.transparentize(60%)),
-      )
-    ]
-  }
+  let top_height = height * 0.3
+  let bottom_height = height * 0.7
 
-  #place(top + right)[
+  let half_height = height / 2
+  let half_width = width / 2
+
+  show par: set block(spacing: 0em)
+
+  pad(1em)[
     #box(
-      width: 360pt,
-      height: 100%,
-      radius: icon_config.padding,
-      fill: gradient.linear(
-        blue.transparentize(80%),
-        red.transparentize(80%),
-        angle: 15deg,
-      ),
-      stroke: gradient.linear(
-        blue,
-        red,
-        angle: 15deg,
-      ) + font_config.inset,
+      stroke: rgb(base7) + 0.15em,
+      radius: 0.6em,
+      clip: true,
     )[
-      #align(center + horizon)[ === Properties ]
+      #align(center + horizon)[
+        #box(
+          width: width,
+          height: top_height,
+          fill: rgb(base3),
+          inset: 0.5em,
+        )[#top_content]
+        #line(length: width, stroke: rgb(base5) + 4pt)
+        #box(
+          width: width,
+          height: bottom_height,
+          fill: rgb(base2),
+          inset: 0.5em,
+        )[#bottom_content]
+      ]
     ]
   ]
+}
+
+#block(width: 1280pt, height: 720pt, inset: font_config.inset)[
+  #gradient_title("Typst")
+  #linebreak()
+  #frame[
+    #icon(emoji.clock.two)
+    #icon(emoji.cloud)
+    #icon(emoji.notebook)
+  ]
+
+  #menu_item([= Test], [#lorem(10)])
 ]

--- a/assets/simple_ui.typ
+++ b/assets/simple_ui.typ
@@ -21,7 +21,6 @@
 
 #set text(size: font_config.size, fill: base8)
 
-// #circle(width: 8pt, stroke: none, fill: base4)
 #let frame(body) = {
   box(
     body,
@@ -32,7 +31,13 @@
 }
 
 #let button(body) = {
-  box(body, inset: isnet, radius: icon_padding, fill: base2)
+  box(
+    body,
+    inset: icon_config.inset * 2,
+    radius: icon_config.padding,
+    fill: base2,
+    stroke: 2pt + base6,
+  )
 }
 
 #let icon(e) = {

--- a/assets/simple_ui.typ
+++ b/assets/simple_ui.typ
@@ -21,6 +21,11 @@
 
 #set text(size: font_config.size, fill: base8)
 
+#let gradient_title(body) = {
+  set text(size: font_config.size, fill: base8)
+  text(fill: gradient.linear(blue, green))[= #body]
+}
+
 #let frame(body) = {
   box(
     body,
@@ -53,12 +58,12 @@
 }
 
 #block(width: 1280pt, height: 720pt, inset: font_config.inset)[
-  #text(fill: gradient.linear(blue, green))[= Smart Assist]
-  #frame[
-    #icon(emoji.clock.two)
-    #icon(emoji.cloud)
-    #icon(emoji.notebook)
-  ]
+  #gradient_title("Typst")
+  // #frame[
+  //   #icon(emoji.clock.two)
+  //   #icon(emoji.cloud)
+  //   #icon(emoji.notebook)
+  // ]
 
   #let size = 400pt
   #let half_size = size / 2

--- a/crates/typst_element/Cargo.toml
+++ b/crates/typst_element/Cargo.toml
@@ -8,3 +8,4 @@ readme.workspace = true
 
 [dependencies]
 typst = { workspace = true }
+unicode-math-class = { workspace = true }

--- a/crates/typst_element/Cargo.toml
+++ b/crates/typst_element/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "typst_element"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+[dependencies]
+typst = { workspace = true }

--- a/crates/typst_element/src/elem.rs
+++ b/crates/typst_element/src/elem.rs
@@ -1,7 +1,9 @@
 use typst::{
     diag::EcoString,
     foundations::{Content, Label, Packed},
-    layout, model, text, visualize,
+    layout,
+    loading::Readable,
+    model, text, visualize,
 };
 
 macro_rules! fn_elem_empty {
@@ -49,7 +51,6 @@ fn_elem!(rotate, layout::RotateElem);
 fn_elem!(hide, layout::HideElem);
 
 // Model
-fn_elem_empty!(outline, model::OutlineElem);
 fn_elem!(doc, model::DocumentElem, Vec<Content>);
 fn_elem!(reference, model::RefElem, Label);
 fn_elem!(
@@ -58,6 +59,7 @@ fn_elem!(
     dest = model::LinkTarget,
     body = Content
 );
+fn_elem_empty!(outline, model::OutlineElem);
 fn_elem!(heading, model::HeadingElem);
 fn_elem!(figure, model::FigureElem);
 fn_elem!(footnote, model::FootnoteElem, model::FootnoteBody);
@@ -92,7 +94,7 @@ fn_elem!(raw, text::RawElem, text::RawContent);
 
 #[macro_export]
 macro_rules! sequence {
-    ($($native_elem:expr),*) => {
+    ($($native_elem:expr),*,) => {
         ::typst::foundations::SequenceElem::new(vec![
             $(::typst::foundations::Content::from($native_elem),)*
         ])
@@ -100,6 +102,24 @@ macro_rules! sequence {
 }
 
 // Visualize
+
+fn_elem!(
+    image,
+    visualize::ImageElem,
+    path = EcoString,
+    readable = Readable
+);
+fn_elem_empty!(line, visualize::LineElem);
+fn_elem_empty!(rect, visualize::RectElem);
+fn_elem_empty!(square, visualize::SquareElem);
+fn_elem_empty!(ellipse, visualize::EllipseElem);
+fn_elem_empty!(circle, visualize::CircleElem);
+fn_elem!(
+    polygon,
+    visualize::PolygonElem,
+    Vec<layout::Axes<layout::Rel<layout::Length>>>
+);
+fn_elem!(path, visualize::PathElem, Vec<visualize::PathVertex>);
 
 pub fn solid(color: visualize::Color) -> visualize::Paint {
     visualize::Paint::Solid(color)
@@ -111,4 +131,8 @@ pub fn gradient(gradient: visualize::Gradient) -> visualize::Paint {
 
 pub fn pattern(pattern: visualize::Pattern) -> visualize::Paint {
     visualize::Paint::Pattern(pattern)
+}
+
+pub fn stroke(paint: visualize::Paint, thickness: layout::Length) -> visualize::Stroke {
+    visualize::Stroke::from_pair(paint, thickness)
 }

--- a/crates/typst_element/src/elem.rs
+++ b/crates/typst_element/src/elem.rs
@@ -5,6 +5,7 @@ use typst::{
     loading::Readable,
     math, model, symbols, text, visualize,
 };
+use unicode_math_class::MathClass;
 
 macro_rules! fn_elem_empty {
     ($fn_name:ident, $elem:ty) => {
@@ -125,6 +126,32 @@ pub fn symbol(c: char) -> symbols::Symbol {
 
 fn_elem!(equation, math::EquationElem);
 fn_elem!(lr, math::LrElem);
+fn_elem!(mid, math::MidElem);
+fn_elem!(attach, math::AttachElem);
+fn_elem!(scripts, math::ScriptsElem);
+fn_elem!(limits, math::LimitsElem);
+fn_elem!(
+    accent,
+    math::AccentElem,
+    body = Content,
+    accent = math::Accent
+);
+fn_elem!(math_underline, math::UnderlineElem);
+fn_elem!(math_overline, math::OverlineElem);
+fn_elem!(underbrace, math::UnderbraceElem);
+fn_elem!(overbrace, math::OverbraceElem);
+fn_elem!(underbracket, math::UnderbracketElem);
+fn_elem!(overbracket, math::OverbracketElem);
+fn_elem!(cancel, math::CancelElem);
+fn_elem!(frac, math::FracElem, num = Content, denom = Content);
+fn_elem!(binom, math::BinomElem, upper = Content, lower = Vec<Content>);
+fn_elem!(vec, math::VecElem, Vec<Content>);
+fn_elem!(mat, math::MatElem, Vec<Vec<Content>>);
+fn_elem!(cases, math::CasesElem, Vec<Content>);
+fn_elem!(root, math::RootElem);
+fn_elem!(class, math::ClassElem, class = MathClass, body = Content);
+fn_elem!(op, math::OpElem);
+fn_elem!(primes, math::PrimesElem, usize);
 
 // Visualize
 

--- a/crates/typst_element/src/elem.rs
+++ b/crates/typst_element/src/elem.rs
@@ -1,6 +1,6 @@
 use typst::{
     diag::EcoString,
-    foundations::{Content, Label, Packed, Style, StyledElem},
+    foundations::{Content, Label, Packed},
     layout, model, text,
 };
 
@@ -97,23 +97,4 @@ macro_rules! sequence {
             $(::typst::foundations::Content::from($native_elem),)*
         ])
     };
-}
-
-pub trait ContentExt {
-    fn style(self, style: impl Into<Style>) -> StyledElem;
-
-    /// Create [`layout::AlignElem`] around the content.
-    fn align(self, alignment: layout::Alignment) -> layout::AlignElem;
-}
-
-impl<T: Into<Content>> ContentExt for T {
-    fn style(self, style: impl Into<Style>) -> StyledElem {
-        let content: Content = self.into();
-
-        StyledElem::new(content, style.into().into())
-    }
-
-    fn align(self, alignment: layout::Alignment) -> layout::AlignElem {
-        align(self.into()).with_alignment(alignment)
-    }
 }

--- a/crates/typst_element/src/elem.rs
+++ b/crates/typst_element/src/elem.rs
@@ -8,6 +8,7 @@ use typst::{
 
 macro_rules! fn_elem_empty {
     ($fn_name:ident, $elem:ty) => {
+        #[doc = concat!("[", stringify!($elem), "]")]
         pub fn $fn_name() -> $elem {
             <$elem>::new()
         }
@@ -16,6 +17,7 @@ macro_rules! fn_elem_empty {
 
 macro_rules! fn_elem {
     ($fn_name:ident, $elem:ty, $($param:ident = $in_elem:ty),+) => {
+        #[doc = concat!("[", stringify!($elem), "]")]
         pub fn $fn_name($($param: impl Into<$in_elem>),+) -> $elem {
             <$elem>::new($($param.into()),+)
         }
@@ -32,6 +34,7 @@ macro_rules! fn_elem {
 
 // Foundations
 
+/// [foundations::SequenceElem]
 #[macro_export]
 macro_rules! sequence {
     ($($native_elem:expr),*,) => {
@@ -41,6 +44,7 @@ macro_rules! sequence {
     };
 }
 
+/// [foundations::ContextElem]
 pub fn context<T: IntoValue>(
     func: foundations::Func,
     args: impl IntoIterator<Item = T>,
@@ -142,18 +146,22 @@ fn_elem!(
 );
 fn_elem!(path, visualize::PathElem, Vec<visualize::PathVertex>);
 
+/// [visualize::Paint::Solid]
 pub fn solid(color: visualize::Color) -> visualize::Paint {
     visualize::Paint::Solid(color)
 }
 
+/// [visualize::Paint::Gradient]
 pub fn gradient(gradient: visualize::Gradient) -> visualize::Paint {
     visualize::Paint::Gradient(gradient)
 }
 
+/// [visualize::Paint::Pattern]
 pub fn pattern(pattern: visualize::Pattern) -> visualize::Paint {
     visualize::Paint::Pattern(pattern)
 }
 
+/// [visualize::Stroke]
 pub fn stroke(paint: visualize::Paint, thickness: layout::Length) -> visualize::Stroke {
     visualize::Stroke::from_pair(paint, thickness)
 }

--- a/crates/typst_element/src/elem.rs
+++ b/crates/typst_element/src/elem.rs
@@ -1,0 +1,100 @@
+use typst::{
+    diag::EcoString,
+    foundations::{Content, Label, Packed},
+    layout, model, text,
+};
+
+macro_rules! fn_elem_empty {
+    ($fn_name:ident, $elem:ty) => {
+        pub fn $fn_name() -> $elem {
+            <$elem>::new()
+        }
+    };
+}
+
+macro_rules! fn_elem {
+    ($fn_name:ident, $elem:ty, $($param:ident = $in_elem:ty),+) => {
+        pub fn $fn_name($($param: impl Into<$in_elem>),+) -> $elem {
+            <$elem>::new($($param.into()),+)
+        }
+    };
+
+    ($fn_name:ident, $elem:ty) => {
+        fn_elem!($fn_name, $elem, body = ::typst::foundations::Content);
+    };
+
+    ($fn_name:ident, $elem:ty, $in_elem:ty) => {
+        fn_elem!($fn_name, $elem, body = $in_elem);
+    };
+}
+
+// Layout
+fn_elem!(page, layout::PageElem);
+fn_elem_empty!(pagebreak, layout::PagebreakElem);
+fn_elem!(vertical, layout::VElem, layout::Spacing);
+fn_elem!(horizontal, layout::HElem, layout::Spacing);
+fn_elem_empty!(boxed, layout::BoxElem);
+fn_elem_empty!(block, layout::BlockElem);
+fn_elem!(stack, layout::StackElem, Vec<layout::StackChild>);
+fn_elem!(grid, layout::GridElem, Vec<layout::GridChild>);
+fn_elem!(column, layout::ColumnsElem);
+fn_elem_empty!(colbreak, layout::ColbreakElem);
+fn_elem!(place, layout::PlaceElem);
+fn_elem!(align, layout::AlignElem);
+fn_elem!(pad, layout::PadElem);
+fn_elem!(repeat, layout::RepeatElem);
+fn_elem!(moved, layout::MoveElem);
+fn_elem!(scale, layout::ScaleElem);
+fn_elem!(rotate, layout::RotateElem);
+fn_elem!(hide, layout::HideElem);
+
+// Model
+fn_elem_empty!(outline, model::OutlineElem);
+fn_elem!(doc, model::DocumentElem, Vec<Content>);
+fn_elem!(reference, model::RefElem, Label);
+fn_elem!(
+    link,
+    model::LinkElem,
+    dest = model::LinkTarget,
+    body = Content
+);
+fn_elem!(heading, model::HeadingElem);
+fn_elem!(figure, model::FigureElem);
+fn_elem!(footnote, model::FootnoteElem, model::FootnoteBody);
+fn_elem!(quote, model::QuoteElem);
+fn_elem!(cite, model::CiteElem, Label);
+fn_elem!(
+    bibliography,
+    model::BibliographyElem,
+    paths = model::BibliographyPaths,
+    bibliography = model::Bibliography
+);
+fn_elem!(numbered_list, model::EnumElem, Vec<Packed<model::EnumItem>>);
+fn_elem!(bullet_list, model::ListElem, Vec<Packed<model::ListItem>>);
+fn_elem_empty!(parbreak, model::ParbreakElem);
+fn_elem!(par, model::ParElem, Vec<Content>);
+fn_elem!(table, model::TableElem, Vec<model::TableChild>);
+fn_elem!(terms, model::TermsElem, Vec<Packed<model::TermItem>>);
+fn_elem!(emph, model::EmphElem);
+fn_elem!(strong, model::StrongElem);
+
+// Text
+fn_elem!(text, text::TextElem, EcoString);
+fn_elem_empty!(linebreak, text::LinebreakElem);
+fn_elem_empty!(smart_quote, text::SmartQuoteElem);
+fn_elem!(subscript, text::SubElem);
+fn_elem!(superscript, text::SuperElem);
+fn_elem!(underline, text::UnderlineElem);
+fn_elem!(overline, text::OverlineElem);
+fn_elem!(strike, text::StrikeElem);
+fn_elem!(highlight, text::HighlightElem);
+fn_elem!(raw, text::RawElem, text::RawContent);
+
+#[macro_export]
+macro_rules! sequence {
+($($native_elem:expr),*) => {
+    ::typst::foundations::SequenceElem::new(vec![
+        $(::typst::foundations::Content::from($native_elem),)*
+    ])
+};
+}

--- a/crates/typst_element/src/elem.rs
+++ b/crates/typst_element/src/elem.rs
@@ -1,7 +1,7 @@
 use typst::{
     diag::EcoString,
     foundations::{Content, Label, Packed},
-    layout, model, text,
+    layout, model, text, visualize,
 };
 
 macro_rules! fn_elem_empty {
@@ -97,4 +97,18 @@ macro_rules! sequence {
             $(::typst::foundations::Content::from($native_elem),)*
         ])
     };
+}
+
+// Visualize
+
+pub fn solid(color: visualize::Color) -> visualize::Paint {
+    visualize::Paint::Solid(color)
+}
+
+pub fn gradient(gradient: visualize::Gradient) -> visualize::Paint {
+    visualize::Paint::Gradient(gradient)
+}
+
+pub fn pattern(pattern: visualize::Pattern) -> visualize::Paint {
+    visualize::Paint::Pattern(pattern)
 }

--- a/crates/typst_element/src/elem.rs
+++ b/crates/typst_element/src/elem.rs
@@ -1,6 +1,6 @@
 use typst::{
     diag::EcoString,
-    foundations::{Content, Label, Packed},
+    foundations::{Content, Label, Packed, Style, StyledElem},
     layout, model, text,
 };
 
@@ -92,9 +92,28 @@ fn_elem!(raw, text::RawElem, text::RawContent);
 
 #[macro_export]
 macro_rules! sequence {
-($($native_elem:expr),*) => {
-    ::typst::foundations::SequenceElem::new(vec![
-        $(::typst::foundations::Content::from($native_elem),)*
-    ])
-};
+    ($($native_elem:expr),*) => {
+        ::typst::foundations::SequenceElem::new(vec![
+            $(::typst::foundations::Content::from($native_elem),)*
+        ])
+    };
+}
+
+pub trait ContentExt {
+    fn style(self, style: impl Into<Style>) -> StyledElem;
+
+    /// Create [`layout::AlignElem`] around the content.
+    fn align(self, alignment: layout::Alignment) -> layout::AlignElem;
+}
+
+impl<T: Into<Content>> ContentExt for T {
+    fn style(self, style: impl Into<Style>) -> StyledElem {
+        let content: Content = self.into();
+
+        StyledElem::new(content, style.into().into())
+    }
+
+    fn align(self, alignment: layout::Alignment) -> layout::AlignElem {
+        align(self.into()).with_alignment(alignment)
+    }
 }

--- a/crates/typst_element/src/elem.rs
+++ b/crates/typst_element/src/elem.rs
@@ -1,9 +1,9 @@
 use typst::{
     diag::EcoString,
-    foundations::{Content, Label, Packed},
+    foundations::{self, Content, IntoValue, Label, Packed},
     layout,
     loading::Readable,
-    model, text, visualize,
+    math, model, symbols, text, visualize,
 };
 
 macro_rules! fn_elem_empty {
@@ -28,6 +28,25 @@ macro_rules! fn_elem {
     ($fn_name:ident, $elem:ty, $in_elem:ty) => {
         fn_elem!($fn_name, $elem, body = $in_elem);
     };
+}
+
+// Foundations
+
+#[macro_export]
+macro_rules! sequence {
+    ($($native_elem:expr),*,) => {
+        ::typst::foundations::SequenceElem::new(vec![
+            $(::typst::foundations::Content::from($native_elem),)*
+        ])
+    };
+}
+
+pub fn context<T: IntoValue>(
+    func: foundations::Func,
+    args: impl IntoIterator<Item = T>,
+) -> foundations::ContextElem {
+    let mut args = foundations::Args::new(func.span(), args);
+    foundations::ContextElem::new(func.with(&mut args))
 }
 
 // Layout
@@ -92,14 +111,16 @@ fn_elem!(strike, text::StrikeElem);
 fn_elem!(highlight, text::HighlightElem);
 fn_elem!(raw, text::RawElem, text::RawContent);
 
-#[macro_export]
-macro_rules! sequence {
-    ($($native_elem:expr),*,) => {
-        ::typst::foundations::SequenceElem::new(vec![
-            $(::typst::foundations::Content::from($native_elem),)*
-        ])
-    };
+// Symbols
+
+pub fn symbol(c: char) -> symbols::Symbol {
+    symbols::Symbol::single(c)
 }
+
+// Math
+
+fn_elem!(equation, math::EquationElem);
+fn_elem!(lr, math::LrElem);
 
 // Visualize
 

--- a/crates/typst_element/src/extensions.rs
+++ b/crates/typst_element/src/extensions.rs
@@ -1,0 +1,97 @@
+use typst::{
+    foundations::{
+        Args, Array, Bytes, Content, Datetime, Dict, Duration, FromValue, Func, Label, Module,
+        Plugin, Scope, Smart, Str, Styles, Type, Version,
+    },
+    layout::{Abs, Angle, Em, Fr, Length, Ratio, Rel},
+    symbols::Symbol,
+    visualize::{Color, Gradient, Pattern},
+};
+
+pub trait UnitExt: Sized {
+    fn length(self) -> Length;
+    fn rel(self) -> Rel;
+
+    fn smart_length(self) -> Smart<Length> {
+        Smart::Custom(self.length())
+    }
+
+    fn smart_rel(self) -> Smart<Rel> {
+        Smart::Custom(self.rel())
+    }
+}
+
+impl UnitExt for Abs {
+    fn length(self) -> Length {
+        Length::from(self)
+    }
+
+    fn rel(self) -> Rel {
+        Rel::from(self)
+    }
+}
+
+impl UnitExt for Em {
+    fn length(self) -> Length {
+        Length::from(self)
+    }
+
+    fn rel(self) -> Rel {
+        Rel::from(self)
+    }
+}
+
+macro_rules! fn_get_unchecked {
+    ($fn_name:ident, $get_ty:ty) => {
+        /// Clone a variable and cast it into the final value _unchecked_.
+        ///
+        /// See [ScopeExt::get_unchecked()].
+        fn $fn_name(&self, var: &str) -> $get_ty {
+            self.get_unchecked(var)
+        }
+    };
+}
+
+pub trait ScopeExt {
+    /// Clone a variable and cast it into the final value _unchecked_.
+    ///
+    /// # Panic
+    ///
+    /// - Variable does not exists.
+    /// - Variable type does not match the desired value type.
+    fn get_unchecked<T: FromValue>(&self, var: &str) -> T;
+
+    fn_get_unchecked!(get_unchecked_bool, bool);
+    fn_get_unchecked!(get_unchecked_int, i64);
+    fn_get_unchecked!(get_unchecked_float, f64);
+    fn_get_unchecked!(get_unchecked_len, Length);
+    fn_get_unchecked!(get_unchecked_angle, Angle);
+    fn_get_unchecked!(get_unchecked_ratio, Ratio);
+    fn_get_unchecked!(get_unchecked_relative, Rel<Length>);
+    fn_get_unchecked!(get_unchecked_fraction, Fr);
+    fn_get_unchecked!(get_unchecked_color, Color);
+    fn_get_unchecked!(get_unchecked_gradient, Gradient);
+    fn_get_unchecked!(get_unchecked_pattern, Pattern);
+    fn_get_unchecked!(get_unchecked_symbol, Symbol);
+    fn_get_unchecked!(get_unchecked_version, Version);
+    fn_get_unchecked!(get_unchecked_str, Str);
+    fn_get_unchecked!(get_unchecked_bytes, Bytes);
+    fn_get_unchecked!(get_unchecked_label, Label);
+    fn_get_unchecked!(get_unchecked_datetime, Datetime);
+    fn_get_unchecked!(get_unchecked_duration, Duration);
+    fn_get_unchecked!(get_unchecked_content, Content);
+    fn_get_unchecked!(get_unchecked_styles, Styles);
+    fn_get_unchecked!(get_unchecked_array, Array);
+    fn_get_unchecked!(get_unchecked_dict, Dict);
+    fn_get_unchecked!(get_unchecked_func, Func);
+    fn_get_unchecked!(get_unchecked_args, Args);
+    fn_get_unchecked!(get_unchecked_type, Type);
+    fn_get_unchecked!(get_unchecked_module, Module);
+    fn_get_unchecked!(get_unchecked_plugin, Plugin);
+}
+
+impl ScopeExt for Scope {
+    fn get_unchecked<T: FromValue>(&self, var: &str) -> T {
+        self.get(var).cloned().unwrap().cast::<T>().unwrap()
+    }
+}

--- a/crates/typst_element/src/lib.rs
+++ b/crates/typst_element/src/lib.rs
@@ -1,15 +1,17 @@
+use foundations::{FromValue, Scope, SequenceElem, Style};
 use prelude::*;
-use typst::foundations::{SequenceElem, Style};
 
 pub mod prelude {
     pub use typst::{
         diag::EcoString,
-        foundations::{Content, Label, NativeElement, Packed, Smart},
+        foundations::{self, Content, Label, NativeElement, Packed, Smart},
         layout::{self, Abs, Em, Length, Ratio, Rel},
-        model, text,
+        math, model, text, visualize,
     };
 
-    pub use crate::{elem::*, sequence, DocWriter, SimpleWriter};
+    pub use crate::{elem::*, sequence};
+    pub use crate::{DocWriter, SimpleWriter};
+    pub use crate::{ScopeExt, UnitExt};
 }
 
 pub mod elem;
@@ -114,5 +116,21 @@ impl UnitExt for Em {
 
     fn rel(self) -> Rel {
         Rel::from(self)
+    }
+}
+
+pub trait ScopeExt {
+    /// Clone a variable and cast it into the final value _unchecked_.
+    ///
+    /// # Panic
+    ///
+    /// - Variable does not exists.
+    /// - Variable type does not match the desired value type.
+    fn get_unchecked<T: FromValue>(&self, var: &str) -> T;
+}
+
+impl ScopeExt for Scope {
+    fn get_unchecked<T: FromValue>(&self, var: &str) -> T {
+        self.get(var).cloned().unwrap().cast::<T>().unwrap()
     }
 }

--- a/crates/typst_element/src/lib.rs
+++ b/crates/typst_element/src/lib.rs
@@ -57,12 +57,7 @@ impl SimpleWriter {
         Self::default()
     }
 
-    pub fn blank_page(
-        &mut self,
-        // width: f64,
-        // height: f64,
-        writer: impl Fn(&mut Self),
-    ) -> ContentMut {
+    pub fn blank_page(&mut self, writer: impl FnOnce(&mut Self)) -> ContentMut {
         let mut doc = Self::default();
         writer(&mut doc);
 

--- a/crates/typst_element/src/lib.rs
+++ b/crates/typst_element/src/lib.rs
@@ -1,0 +1,120 @@
+use typst::{
+    diag::EcoString,
+    foundations::{Content, Label, Packed, Smart},
+    layout, model, text,
+};
+
+// TODO: Create a unit generator.
+/// Length in absolute points.
+pub fn length_abs(abs: layout::Abs) -> layout::Length {
+    layout::Length::from(abs)
+}
+
+pub fn abs_pt(pt: f64) -> layout::Length {
+    layout::Length::from(layout::Abs::pt(pt))
+}
+
+/// Absolute length in points.
+pub fn pt(pt: f64) -> layout::Abs {
+    layout::Abs::pt(pt)
+}
+
+macro_rules! fn_elem_empty {
+    ($fn_name:ident, $elem:ty) => {
+        pub fn $fn_name() -> $elem {
+            <$elem>::new()
+        }
+    };
+}
+
+macro_rules! fn_elem {
+    ($fn_name:ident, $elem:ty, $($param:ident = $in_elem:ty),+) => {
+        pub fn $fn_name($($param: impl Into<$in_elem>),+) -> $elem {
+            <$elem>::new($($param.into()),+)
+        }
+    };
+
+    ($fn_name:ident, $elem:ty) => {
+        fn_elem!($fn_name, $elem, body = ::typst::foundations::Content);
+    };
+
+    ($fn_name:ident, $elem:ty, $in_elem:ty) => {
+        fn_elem!($fn_name, $elem, body = $in_elem);
+    };
+}
+
+// Layout
+fn_elem!(page, layout::PageElem);
+fn_elem_empty!(pagebreak, layout::PagebreakElem);
+fn_elem!(vertical, layout::VElem, layout::Spacing);
+fn_elem!(horizontal, layout::HElem, layout::Spacing);
+fn_elem_empty!(boxed, layout::BoxElem);
+fn_elem_empty!(block, layout::BlockElem);
+fn_elem!(stack, layout::StackElem, Vec<layout::StackChild>);
+fn_elem!(grid, layout::GridElem, Vec<layout::GridChild>);
+fn_elem!(column, layout::ColumnsElem);
+fn_elem_empty!(colbreak, layout::ColbreakElem);
+fn_elem!(place, layout::PlaceElem);
+fn_elem!(align, layout::AlignElem);
+fn_elem!(pad, layout::PadElem);
+fn_elem!(repeat, layout::RepeatElem);
+fn_elem!(moved, layout::MoveElem);
+fn_elem!(scale, layout::ScaleElem);
+fn_elem!(rotate, layout::RotateElem);
+fn_elem!(hide, layout::HideElem);
+
+// Model
+fn_elem_empty!(outline, model::OutlineElem);
+fn_elem!(doc, model::DocumentElem, Vec<Content>);
+fn_elem!(reference, model::RefElem, Label);
+fn_elem!(
+    link,
+    model::LinkElem,
+    dest = model::LinkTarget,
+    body = Content
+);
+fn_elem!(heading, model::HeadingElem);
+fn_elem!(figure, model::FigureElem);
+fn_elem!(footnote, model::FootnoteElem, model::FootnoteBody);
+fn_elem!(quote, model::QuoteElem);
+fn_elem!(cite, model::CiteElem, Label);
+fn_elem!(
+    bibliography,
+    model::BibliographyElem,
+    paths = model::BibliographyPaths,
+    bibliography = model::Bibliography
+);
+fn_elem!(numbered_list, model::EnumElem, Vec<Packed<model::EnumItem>>);
+fn_elem!(bullet_list, model::ListElem, Vec<Packed<model::ListItem>>);
+fn_elem_empty!(parbreak, model::ParbreakElem);
+fn_elem!(par, model::ParElem, Vec<Content>);
+fn_elem!(table, model::TableElem, Vec<model::TableChild>);
+fn_elem!(terms, model::TermsElem, Vec<Packed<model::TermItem>>);
+fn_elem!(emph, model::EmphElem);
+fn_elem!(strong, model::StrongElem);
+
+// Text
+fn_elem!(text, text::TextElem, EcoString);
+fn_elem_empty!(linebreak, text::LinebreakElem);
+fn_elem_empty!(smart_quote, text::SmartQuoteElem);
+fn_elem!(subscript, text::SubElem);
+fn_elem!(superscript, text::SuperElem);
+fn_elem!(underline, text::UnderlineElem);
+fn_elem!(overline, text::OverlineElem);
+fn_elem!(strike, text::StrikeElem);
+fn_elem!(highlight, text::HighlightElem);
+fn_elem!(raw, text::RawElem, text::RawContent);
+
+#[macro_export]
+macro_rules! sequence {
+    ($($native_elem:expr),*) => {
+        ::typst::foundations::SequenceElem::new(vec![
+            $(::typst::foundations::Content::from($native_elem),)*
+        ])
+    };
+}
+
+#[derive(Default)]
+pub struct ElemBuilder(pub Vec<Content>);
+
+impl ElemBuilder {}

--- a/crates/typst_element/src/lib.rs
+++ b/crates/typst_element/src/lib.rs
@@ -1,4 +1,4 @@
-use foundations::{FromValue, Scope, SequenceElem, Style};
+use foundations::{SequenceElem, Style};
 use prelude::*;
 
 pub mod prelude {
@@ -9,12 +9,13 @@ pub mod prelude {
         math, model, text, visualize,
     };
 
+    pub use crate::extensions::{ScopeExt, UnitExt};
     pub use crate::{elem::*, sequence};
     pub use crate::{DocWriter, SimpleWriter};
-    pub use crate::{ScopeExt, UnitExt};
 }
 
 pub mod elem;
+pub mod extensions;
 
 pub trait DocWriter: Sized {
     /// A immutable reference to all contents within the writer.
@@ -83,54 +84,5 @@ impl<'a> ContentMut<'a> {
 
     pub fn as_content(self) -> &'a mut Content {
         self.0
-    }
-}
-
-pub trait UnitExt: Sized {
-    fn length(self) -> Length;
-    fn rel(self) -> Rel;
-
-    fn smart_length(self) -> Smart<Length> {
-        Smart::Custom(self.length())
-    }
-
-    fn smart_rel(self) -> Smart<Rel> {
-        Smart::Custom(self.rel())
-    }
-}
-
-impl UnitExt for Abs {
-    fn length(self) -> Length {
-        Length::from(self)
-    }
-
-    fn rel(self) -> Rel {
-        Rel::from(self)
-    }
-}
-
-impl UnitExt for Em {
-    fn length(self) -> Length {
-        Length::from(self)
-    }
-
-    fn rel(self) -> Rel {
-        Rel::from(self)
-    }
-}
-
-pub trait ScopeExt {
-    /// Clone a variable and cast it into the final value _unchecked_.
-    ///
-    /// # Panic
-    ///
-    /// - Variable does not exists.
-    /// - Variable type does not match the desired value type.
-    fn get_unchecked<T: FromValue>(&self, var: &str) -> T;
-}
-
-impl ScopeExt for Scope {
-    fn get_unchecked<T: FromValue>(&self, var: &str) -> T {
-        self.get(var).cloned().unwrap().cast::<T>().unwrap()
     }
 }

--- a/crates/typst_element/src/lib.rs
+++ b/crates/typst_element/src/lib.rs
@@ -59,28 +59,17 @@ impl SimpleWriter {
 
     pub fn blank_page(
         &mut self,
-        width: f64,
-        height: f64,
+        // width: f64,
+        // height: f64,
         writer: impl Fn(&mut Self),
     ) -> ContentMut {
         let mut doc = Self::default();
         writer(&mut doc);
 
-        let page_elem = page(
-            scale(
-                block()
-                    .with_width(Abs::pt(width).smart_rel())
-                    .with_height(Abs::pt(height).smart_rel())
-                    .with_body(Some(doc.pack())),
-            )
-            // Ratio needed to convert pt to pixels
-            .with_x(Ratio::new(0.75))
-            .with_y(Ratio::new(0.75))
-            .with_reflow(true),
-        )
-        .with_width(Smart::Auto)
-        .with_height(Smart::Auto)
-        .with_margin(layout::Margin::splat(Some(Abs::zero().smart_rel())));
+        let page_elem = page(doc.pack())
+            .with_width(Smart::Auto)
+            .with_height(Smart::Auto)
+            .with_margin(layout::Margin::splat(Some(Abs::zero().smart_rel())));
 
         self.add_content(page_elem.pack())
     }

--- a/crates/typst_vello/Cargo.toml
+++ b/crates/typst_vello/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "typst_vello"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+[dependencies]

--- a/crates/typst_vello/src/lib.rs
+++ b/crates/typst_vello/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/typst_vello/src/lib.rs
+++ b/crates/typst_vello/src/lib.rs
@@ -1,14 +1,3 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+//! # Typst Vello
+//!
+//! A Vello scene drawer for Typst's frames.

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use bevy_typst::prelude::*;
 use bevy_vello::{VelloAssetBundle, VelloPlugin};
+use typst::foundations::Label;
 
 fn main() {
     App::new()
@@ -9,14 +10,15 @@ fn main() {
         // Custom plugins
         .add_plugins((TypstPlugin::default(), VelloPlugin))
         .add_systems(Startup, setup)
-        .add_systems(Update, (print_document, print_svg))
+        .add_systems(Update, (check_document, check_module, check_svg))
         .run();
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn((
-        asset_server.load::<TypstAsset>("hello_world.typ"),
+        asset_server.load::<TypstDocAsset>("hello_world.typ"),
+        asset_server.load::<TypstModAsset>("hello_world.typ"),
         asset_server.load::<SvgAsset>("hello_world.typ"),
         VelloAssetBundle {
             vector: asset_server.load("hello_world.typ"),
@@ -25,22 +27,45 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ));
 }
 
-fn print_document(
+fn check_document(
     mut commands: Commands,
-    q_typst_asset: Query<(Entity, &Handle<TypstAsset>)>,
-    typst_assets: Res<Assets<TypstAsset>>,
+    q_typst_asset: Query<(Entity, &Handle<TypstDocAsset>)>,
+    typst_doc_assets: Res<Assets<TypstDocAsset>>,
 ) {
     let Ok((entity, handle)) = q_typst_asset.get_single() else {
         return;
     };
 
-    if typst_assets.get(handle).is_some() {
+    if typst_doc_assets.get(handle).is_some() {
         info!("Has document.");
-        commands.entity(entity).remove::<Handle<TypstAsset>>();
+        commands.entity(entity).remove::<Handle<TypstDocAsset>>();
     }
 }
 
-fn print_svg(
+fn check_module(
+    mut commands: Commands,
+    q_typst_asset: Query<(Entity, &Handle<TypstModAsset>)>,
+    typst_mod_assets: Res<Assets<TypstModAsset>>,
+) {
+    let Ok((entity, handle)) = q_typst_asset.get_single() else {
+        return;
+    };
+
+    if let Some(module) = typst_mod_assets.get(handle).map(|asset| asset.module()) {
+        info!("Has module.");
+        let typst_title =
+            module
+                .clone()
+                .content()
+                .query_first(typst::foundations::Selector::Label(Label::new(
+                    "typst_title",
+                )));
+        println!("typst_title: {typst_title:?}");
+        commands.entity(entity).remove::<Handle<TypstModAsset>>();
+    }
+}
+
+fn check_svg(
     mut commands: Commands,
     q_svg_asset: Query<(Entity, &Handle<SvgAsset>)>,
     svg_assets: Res<Assets<SvgAsset>>,

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -1,11 +1,10 @@
 use bevy::{prelude::*, ui::FocusPolicy, window::PrimaryWindow};
 use bevy_typst::{
-    compiler::{TypstCompiler, TypstScene},
+    compiler::{world::TypstWorldMeta, TypstCompiler, TypstScene},
     prelude::*,
 };
 use bevy_vello::{prelude::*, VelloPlugin};
-use typst::visualize;
-use typst_element::{prelude::*, UnitExt};
+use typst_element::prelude::*;
 
 fn main() {
     App::new()
@@ -14,63 +13,27 @@ fn main() {
         // Custom plugins
         .add_plugins((TypstPlugin::default(), VelloPlugin))
         .add_systems(Startup, setup)
-        .add_systems(
-            Update,
-            (
-                init_template.run_if(not(resource_exists::<Template>)),
-                ui_update.run_if(resource_exists::<Template>),
-            ),
-        )
+        .add_systems(Update, init_ui)
         .run();
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(asset_server.load::<TypstModAsset>("simple_ui.typ"));
-
-    // let value = module.scope().get("red").unwrap();
-    // let color = value.clone().cast::<typst::visualize::Color>();
-    // println!("{color:?}");
-
-    commands.spawn(VelloSceneBundle {
-        coordinate_space: CoordinateSpace::ScreenSpace,
-        ..default()
-    });
 }
 
-#[derive(Resource)]
-struct Template {
-    pub frame: typst::foundations::Func,
-    pub button: typst::foundations::Func,
-    pub icon: typst::foundations::Func,
-}
-
-#[derive(Resource)]
-struct ColorTemplate {
-    pub red: typst::visualize::Color,
-    pub orange: typst::visualize::Color,
-    pub yellow: typst::visualize::Color,
-    pub green: typst::visualize::Color,
-    pub blue: typst::visualize::Color,
-    pub purple: typst::visualize::Color,
-    pub base0: typst::visualize::Color,
-    pub base1: typst::visualize::Color,
-    pub base2: typst::visualize::Color,
-    pub base3: typst::visualize::Color,
-    pub base4: typst::visualize::Color,
-    pub base5: typst::visualize::Color,
-    pub base6: typst::visualize::Color,
-    pub base7: typst::visualize::Color,
-    pub base8: typst::visualize::Color,
-}
-
-pub struct Test;
-
-fn init_template(
+fn init_ui(
     mut commands: Commands,
     q_simple_ui: Query<&Handle<TypstModAsset>>,
     typst_mod_assets: Res<Assets<TypstModAsset>>,
+    compiler: Res<TypstCompiler>,
+    mut initialized: Local<bool>,
 ) {
+    if *initialized {
+        return;
+    }
+
+    let world = compiler.world_meta();
     let Ok(simple_ui) = q_simple_ui.get_single() else {
         return;
     };
@@ -78,145 +41,77 @@ fn init_template(
     if let Some(module) = typst_mod_assets.get(simple_ui).map(|asset| asset.module()) {
         let scope = module.scope();
 
-        let red = scope.get("red").unwrap().clone();
-        let orange = scope.get("orange").unwrap().clone();
-        let yellow = scope.get("yellow").unwrap().clone();
-        let green = scope.get("green").unwrap().clone();
-        let blue = scope.get("blue").unwrap().clone();
-        let purple = scope.get("purple").unwrap().clone();
-        let base0 = scope.get("base0").unwrap().clone();
-        let base1 = scope.get("base1").unwrap().clone();
-        let base2 = scope.get("base2").unwrap().clone();
-        let base3 = scope.get("base3").unwrap().clone();
-        let base4 = scope.get("base4").unwrap().clone();
-        let base5 = scope.get("base5").unwrap().clone();
-        let base6 = scope.get("base6").unwrap().clone();
-        let base7 = scope.get("base7").unwrap().clone();
-        let base8 = scope.get("base8").unwrap().clone();
+        let red = scope.get_unchecked::<visualize::Color>("red");
+        let orange = scope.get_unchecked::<visualize::Color>("orange");
+        let yellow = scope.get_unchecked::<visualize::Color>("yellow");
+        let green = scope.get_unchecked::<visualize::Color>("green");
+        let blue = scope.get_unchecked::<visualize::Color>("blue");
+        let purple = scope.get_unchecked::<visualize::Color>("purple");
+        let base0 = scope.get_unchecked::<visualize::Color>("base0");
+        let base1 = scope.get_unchecked::<visualize::Color>("base1");
+        let base2 = scope.get_unchecked::<visualize::Color>("base2");
+        let base3 = scope.get_unchecked::<visualize::Color>("base3");
+        let base4 = scope.get_unchecked::<visualize::Color>("base4");
+        let base5 = scope.get_unchecked::<visualize::Color>("base5");
+        let base6 = scope.get_unchecked::<visualize::Color>("base6");
+        let base7 = scope.get_unchecked::<visualize::Color>("base7");
+        let base8 = scope.get_unchecked::<visualize::Color>("base8");
 
-        commands.insert_resource(ColorTemplate {
-            red: red.cast::<typst::visualize::Color>().unwrap(),
-            orange: orange.cast::<typst::visualize::Color>().unwrap(),
-            yellow: yellow.cast::<typst::visualize::Color>().unwrap(),
-            green: green.cast::<typst::visualize::Color>().unwrap(),
-            blue: blue.cast::<typst::visualize::Color>().unwrap(),
-            purple: purple.cast::<typst::visualize::Color>().unwrap(),
-            base0: base0.cast::<typst::visualize::Color>().unwrap(),
-            base1: base1.cast::<typst::visualize::Color>().unwrap(),
-            base2: base2.cast::<typst::visualize::Color>().unwrap(),
-            base3: base3.cast::<typst::visualize::Color>().unwrap(),
-            base4: base4.cast::<typst::visualize::Color>().unwrap(),
-            base5: base5.cast::<typst::visualize::Color>().unwrap(),
-            base6: base6.cast::<typst::visualize::Color>().unwrap(),
-            base7: base7.cast::<typst::visualize::Color>().unwrap(),
-            base8: base8.cast::<typst::visualize::Color>().unwrap(),
-        });
+        let gradient_title = scope.get_unchecked::<foundations::Func>("gradient_title");
+        let frame = scope.get_unchecked::<foundations::Func>("frame");
+        let button = scope.get_unchecked::<foundations::Func>("button");
+        let icon = scope.get_unchecked::<foundations::Func>("icon");
 
-        let frame = scope.get("frame").unwrap().clone();
-        let button = scope.get("button").unwrap().clone();
-        let icon = scope.get("icon").unwrap().clone();
+        // Create ui
+        commands
+            .spawn(EmptyNodeBundle {
+                style: Style {
+                    width: Val::Percent(100.0),
+                    height: Val::Percent(100.0),
+                    justify_content: JustifyContent::SpaceBetween,
+                    padding: UiRect::all(Val::Px(40.0)),
+                    ..default()
+                },
+                ..default()
+            })
+            .with_children(|parent| {
+                let mut writer = SimpleWriter::new();
+                writer.blank_page(|writer| {
+                    writer.add_content(context(gradient_title.clone(), ["Typst"]));
+                });
 
-        commands.insert_resource(Template {
-            frame: frame.cast::<typst::foundations::Func>().unwrap(),
-            button: button.cast::<typst::foundations::Func>().unwrap(),
-            icon: icon.cast::<typst::foundations::Func>().unwrap(),
-        });
+                let scene = typst_scene(writer, world);
+                parent
+                    .spawn(EmptyNodeBundle::from_typst(&scene))
+                    .insert(vello_scene(scene));
+            })
+            .with_children(|parent| {
+                let mut writer = SimpleWriter::new();
+                writer.blank_page(|writer| {
+                    writer.add_content(context(gradient_title, ["Typst"]));
+                });
+
+                let scene = typst_scene(writer, world);
+                parent
+                    .spawn(EmptyNodeBundle::from_typst(&scene))
+                    .insert(vello_scene(scene));
+            });
+
+        *initialized = true;
     }
 }
 
-fn ui_update(
-    mut q_scene: Query<&mut VelloScene>,
-    q_window: Query<&Window, With<PrimaryWindow>>,
-    world: Res<TypstCompiler>,
-    time: Res<Time>,
-    template: Res<Template>,
-    color_template: Res<ColorTemplate>,
-) {
-    let world = world.world_meta();
-    let Ok(window) = q_window.get_single() else {
-        return;
-    };
-
-    let width = window.width() as f64;
-    let height = window.height() as f64;
-
-    if width <= 0.0 || height <= 0.0 {
-        return;
-    }
-
-    let Ok(mut scene) = q_scene.get_single_mut() else {
-        return;
-    };
-
-    let mut writer = SimpleWriter::new();
-
-    let frame = world.eval_func::<Content>(&template.frame, [text("Frame example")]);
-    let button = world.eval_func::<Content>(&template.button, [text("Button example")]);
-
-    writer.blank_page(|writer| {
-        writer.add_content(
-            sequence!(
-                heading(text(time.elapsed_seconds().to_string()))
-                    .pack()
-                    .styled(text::TextElem::set_fill(solid(color_template.blue))),
-                text((1.0 / time.delta_seconds()).to_string()),
-                linebreak(),
-                frame.clone(),
-                linebreak(),
-                frame.clone(),
-                linebreak(),
-                frame.clone(),
-                linebreak(),
-                frame.clone(),
-                linebreak(),
-                button
-            )
-            .pack()
-            .aligned(layout::Alignment::Both(
-                layout::HAlignment::Center,
-                layout::VAlignment::Horizon,
-            )),
-        );
-    });
-
-    let content = writer
-        .pack()
-        .styled(text::TextElem::set_fill(visualize::Paint::Solid(
-            visualize::Color::WHITE,
-        )))
-        .styled(text::TextElem::set_size(text::TextSize(
-            Abs::pt(24.0).length(),
-        )));
-
-    // let context_elem = typst::foundations::ContextElem::new(template.frame.clone()).pack();
-
-    let document = world.compile_content(content).unwrap();
-    let typst_scene = TypstScene::from_document(&document, Abs::zero()).unwrap();
-
-    *scene = typst_scene.as_component();
+fn typst_scene(writer: impl DocWriter, world: &TypstWorldMeta) -> TypstScene {
+    let document = world.compile_content(writer.pack()).unwrap();
+    TypstScene::from_document(&document, Abs::zero()).unwrap()
 }
 
-// pub struct UiWriter<'w, 's>(Vec<Content>, Commands<'w, 's>);
-pub struct UiWriter(Vec<Content>);
-
-impl DocWriter for UiWriter {
-    fn contents(&self) -> &Vec<Content> {
-        &self.0
+fn vello_scene(scene: TypstScene) -> VelloSceneBundle {
+    VelloSceneBundle {
+        scene: VelloScene::from(scene.scene),
+        coordinate_space: CoordinateSpace::ScreenSpace,
+        ..default()
     }
-
-    fn contents_mut(&mut self) -> &mut Vec<Content> {
-        &mut self.0
-    }
-
-    fn take_contents(self) -> Vec<Content> {
-        self.0
-    }
-}
-
-impl UiWriter {
-    // pub fn commands(&mut self) -> Commands {
-    //     self.1.reborrow()
-    // }
 }
 
 #[derive(Bundle, Clone, Debug, Default)]
@@ -246,4 +141,17 @@ pub struct EmptyNodeBundle {
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+}
+
+impl EmptyNodeBundle {
+    pub fn from_typst(scene: &TypstScene) -> Self {
+        Self {
+            style: Style {
+                width: Val::Px(scene.width),
+                height: Val::Px(scene.height),
+                ..default()
+            },
+            ..default()
+        }
+    }
 }

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, ui::FocusPolicy, window::PrimaryWindow};
+use bevy::{prelude::*, ui::FocusPolicy};
 use bevy_typst::{
     compiler::{world::TypstWorldMeta, TypstCompiler, TypstScene},
     prelude::*,
@@ -41,26 +41,9 @@ fn init_ui(
     if let Some(module) = typst_mod_assets.get(simple_ui).map(|asset| asset.module()) {
         let scope = module.scope();
 
-        let red = scope.get_unchecked::<visualize::Color>("red");
-        let orange = scope.get_unchecked::<visualize::Color>("orange");
-        let yellow = scope.get_unchecked::<visualize::Color>("yellow");
-        let green = scope.get_unchecked::<visualize::Color>("green");
-        let blue = scope.get_unchecked::<visualize::Color>("blue");
-        let purple = scope.get_unchecked::<visualize::Color>("purple");
-        let base0 = scope.get_unchecked::<visualize::Color>("base0");
-        let base1 = scope.get_unchecked::<visualize::Color>("base1");
-        let base2 = scope.get_unchecked::<visualize::Color>("base2");
-        let base3 = scope.get_unchecked::<visualize::Color>("base3");
-        let base4 = scope.get_unchecked::<visualize::Color>("base4");
-        let base5 = scope.get_unchecked::<visualize::Color>("base5");
-        let base6 = scope.get_unchecked::<visualize::Color>("base6");
-        let base7 = scope.get_unchecked::<visualize::Color>("base7");
-        let base8 = scope.get_unchecked::<visualize::Color>("base8");
-
-        let gradient_title = scope.get_unchecked::<foundations::Func>("gradient_title");
-        let frame = scope.get_unchecked::<foundations::Func>("frame");
-        let button = scope.get_unchecked::<foundations::Func>("button");
-        let icon = scope.get_unchecked::<foundations::Func>("icon");
+        let purple = scope.get_unchecked_color("purple");
+        let gradient_title = scope.get_unchecked_func("gradient_title");
+        let menu_item = scope.get_unchecked_func("menu_item");
 
         // Create ui
         commands
@@ -68,8 +51,8 @@ fn init_ui(
                 style: Style {
                     width: Val::Percent(100.0),
                     height: Val::Percent(100.0),
-                    justify_content: JustifyContent::SpaceBetween,
-                    padding: UiRect::all(Val::Px(40.0)),
+                    flex_direction: FlexDirection::Column,
+                    padding: UiRect::all(Val::Px(60.0)),
                     ..default()
                 },
                 ..default()
@@ -86,15 +69,74 @@ fn init_ui(
                     .insert(vello_scene(scene));
             })
             .with_children(|parent| {
-                let mut writer = SimpleWriter::new();
-                writer.blank_page(|writer| {
-                    writer.add_content(context(gradient_title, ["Typst"]));
+                parent.spawn(EmptyNodeBundle {
+                    style: Style {
+                        flex_grow: 1.0,
+                        ..default()
+                    },
+                    ..default()
                 });
 
-                let scene = typst_scene(writer, world);
                 parent
-                    .spawn(EmptyNodeBundle::from_typst(&scene))
-                    .insert(vello_scene(scene));
+                    .spawn(EmptyNodeBundle {
+                        style: Style {
+                            flex_direction: FlexDirection::Row,
+                            justify_items: JustifyItems::Center,
+                            justify_content: JustifyContent::Center,
+                            ..default()
+                        },
+                        ..default()
+                    })
+                    .with_children(|parent| {
+                        let create_menu = |title: Content, body: Content| -> TypstScene {
+                            let mut writer = SimpleWriter::new();
+                            writer.blank_page(|writer| {
+                                writer.add_content(context(menu_item.clone(), [title, body]));
+                            });
+                            typst_scene(writer, world)
+                        };
+
+                        // First item
+                        let scene0 = create_menu(
+                            heading(text("Model"))
+                                .pack()
+                                .styled(text::TextElem::set_fill(solid(purple))),
+                            text("Document structuring.").pack(),
+                        );
+                        parent
+                            .spawn(EmptyNodeBundle::from_typst(&scene0))
+                            .insert(vello_scene(scene0));
+
+                        // Second item
+                        let scene1 = create_menu(
+                            heading(text("Layout"))
+                                .pack()
+                                .styled(text::TextElem::set_fill(solid(purple))),
+                            text("Arranging elements on the page in different ways.").pack(),
+                        );
+                        parent
+                            .spawn(EmptyNodeBundle::from_typst(&scene1))
+                            .insert(vello_scene(scene1));
+
+                        // Third item
+                        let scene2 = create_menu(
+                            heading(text("Visualize"))
+                                .pack()
+                                .styled(text::TextElem::set_fill(solid(purple))),
+                            text("Drawing and data visualization.").pack(),
+                        );
+                        parent
+                            .spawn(EmptyNodeBundle::from_typst(&scene2))
+                            .insert(vello_scene(scene2));
+                    });
+
+                parent.spawn(EmptyNodeBundle {
+                    style: Style {
+                        flex_grow: 1.0,
+                        ..default()
+                    },
+                    ..default()
+                });
             });
 
         *initialized = true;

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -3,16 +3,12 @@ use bevy_typst::{
     compiler::{TypstCompiler, TypstScene},
     prelude::*,
 };
-use bevy_vello::{VelloAssetBundle, VelloPlugin, VelloScene, VelloSceneBundle};
+use bevy_vello::{VelloPlugin, VelloScene, VelloSceneBundle};
 use typst::{
-    foundations::{Content, FromValue, NativeElement, SequenceElem, Smart},
-    layout::{
-        Abs, AlignElem, Alignment, BlockElem, BoxElem, HAlignment, Length, Margin, PageElem, Ratio,
-        Rel, VAlignment,
-    },
-    model::HeadingElem,
-    text::TextElem,
+    foundations::{Content, NativeElement, SequenceElem, Smart, Style},
+    layout::{self, Abs},
 };
+use typst_element::{align, block, heading, page, scale, sequence, text};
 
 fn main() {
     App::new()
@@ -45,8 +41,8 @@ fn ui_update(
         return;
     };
 
-    let width = window.width() as f64 / 1.3333334;
-    let height = window.height() as f64 / 1.3333334;
+    let width = window.width() as f64;
+    let height = window.height() as f64;
 
     println!("width: {width}, height: {height}");
 
@@ -54,26 +50,48 @@ fn ui_update(
         return;
     };
 
-    let content = PageElem::new(
-        SequenceElem::new(vec![
-            HeadingElem::new(TextElem::new(time.elapsed_seconds().to_string().into()).pack())
-                .pack(),
-            TextElem::new((1.0 / time.delta_seconds()).to_string().into()).pack(),
-        ])
-        .pack(),
+    fn length(pt: f64) -> layout::Length {
+        layout::Length::from(layout::Abs::pt(pt))
+    }
+
+    let content = align(
+        page(
+            scale(
+                block()
+                    .with_width(Smart::Custom(layout::Rel::new(
+                        layout::Ratio::zero(),
+                        length(width),
+                    )))
+                    .with_height(Smart::Custom(layout::Rel::new(
+                        layout::Ratio::zero(),
+                        length(height),
+                    )))
+                    .with_body(Some(
+                        sequence!(
+                            heading(text(time.elapsed_seconds().to_string())),
+                            text((1.0 / time.delta_seconds()).to_string())
+                        )
+                        .pack(),
+                    )),
+            )
+            .with_x(layout::Ratio::new(0.75))
+            .with_y(layout::Ratio::new(0.75))
+            .with_reflow(true),
+        )
+        .with_width(Smart::Auto)
+        .with_height(Smart::Auto)
+        .with_margin(layout::Margin::splat(Some(Smart::Custom(
+            layout::Rel::zero(),
+        )))),
     )
-    .with_width(Smart::Custom(Length::from(Abs::pt(width))))
-    .with_height(Smart::Custom(Length::from(Abs::pt(height))))
-    .with_margin(Margin::splat(Some(Smart::Custom(Rel::zero()))))
-    .pack()
-    .styled(AlignElem::set_alignment(Alignment::Both(
-        HAlignment::Center,
-        VAlignment::Horizon,
-    )));
+    .with_alignment(layout::Alignment::Both(
+        layout::HAlignment::Center,
+        layout::VAlignment::Horizon,
+    ))
+    .pack();
 
     let mut document = world.compile_content(content).unwrap();
     let frame = std::mem::take(&mut document.pages[0].frame);
-    // println!("{:?}", frame.width().to_raw());
     document.pages[0].frame = frame.mark_box();
     let typst_scene = TypstScene::from_document(&document, Abs::zero()).unwrap();
 
@@ -84,4 +102,120 @@ fn ui_update(
 
     *transform = Transform::from_xyz(-typst_scene.width * 0.5, typst_scene.height * 0.5, 0.0);
     *scene = typst_scene.as_component();
+}
+
+#[derive(Default)]
+pub struct TypstBuidler(pub Vec<Content>);
+
+impl TypstBuidler {
+    pub fn add_content(&mut self, content: Content) -> &mut Content {
+        self.0.push(content);
+        self.0.last_mut().unwrap()
+    }
+
+    pub fn pack(self) -> Content {
+        SequenceElem::new(self.0).pack()
+    }
+}
+
+impl TypstBuidler {
+    pub fn new(children: Vec<Content>) -> Self {
+        Self(children)
+    }
+
+    // pub fn page(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
+    //     let mut builder = Self::default();
+    //     builder_fn(&mut builder);
+
+    //     let content = PageElem::new(builder.pack()).pack();
+    //     ContentMut(self.add_content(content))
+    // }
+
+    // pub fn text(&mut self, text: impl Into<EcoString>) -> ContentMut {
+    //     let content = TextElem::new(text.into()).pack();
+    //     ContentMut(self.add_content(content))
+    // }
+
+    // // pub fn quote(&mut self, builder_fn: impl Fn(&mut SequenceBuidler)) -> ContentMut {
+    // //     let mut builder = Self::default();
+    // //     builder_fn(&mut builder);
+
+    // //     let content = QuoteElem::new(builder.pack()).pack();
+    // //     ContentMut(self.add_content(content))
+    // // }
+
+    // pub fn heading(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
+    //     let mut builder = Self::default();
+    //     builder_fn(&mut builder);
+
+    //     let content = HeadingElem::new(builder.pack()).pack();
+    //     ContentMut(self.add_content(content))
+    // }
+
+    // // pub fn boxed(&mut self, builder_fn: impl Fn(&mut SequenceBuidler)) -> ContentMut {
+    // //     let mut builder = Self::default();
+    // //     builder_fn(&mut builder);
+
+    // //     let mut content = BoxElem::new().with_body();
+    // //     let content = BoxElem::new(builder.pack()).pack();
+    // //     ContentMut(self.add_content(content))
+    // // }
+
+    // pub fn par(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
+    //     let mut builder = Self::default();
+    //     builder_fn(&mut builder);
+
+    //     let content = ParElem::new(builder.0).pack();
+    //     ContentMut(self.add_content(content))
+    // }
+
+    // pub fn linebreak(&mut self) -> ContentMut {
+    //     let content = LinebreakElem::new().pack();
+    //     ContentMut(self.add_content(content))
+    // }
+
+    // pub fn parbreak(&mut self) -> ContentMut {
+    //     let content = ParbreakElem::new().pack();
+    //     ContentMut(self.add_content(content))
+    // }
+
+    // pub fn bullet_list(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
+    //     let mut builder = Self::default();
+    //     builder_fn(&mut builder);
+
+    //     let content = ListElem::new(
+    //         builder
+    //             .0
+    //             .drain(..)
+    //             .map(|c| Packed::new(ListItem::new(c)))
+    //             .collect(),
+    //     )
+    //     .pack();
+    //     ContentMut(self.add_content(content))
+    // }
+
+    // pub fn numbered_list(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
+    //     let mut builder = Self::default();
+    //     builder_fn(&mut builder);
+
+    //     let content = EnumElem::new(
+    //         builder
+    //             .0
+    //             .drain(..)
+    //             .map(|c| Packed::new(EnumItem::new(c)))
+    //             .collect(),
+    //     )
+    //     .pack();
+    //     ContentMut(self.add_content(content))
+    // }
+}
+
+pub struct ContentMut<'a>(&'a mut Content);
+
+impl<'a> ContentMut<'a> {
+    pub fn style(self, style: impl Into<Style>) -> Self {
+        let content_value = std::mem::take(self.0);
+        *self.0 = content_value.styled(style);
+        self
+    }
 }

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -1,10 +1,11 @@
-use bevy::{prelude::*, window::PrimaryWindow};
+use bevy::{prelude::*, ui::FocusPolicy, window::PrimaryWindow};
 use bevy_typst::{
     compiler::{TypstCompiler, TypstScene},
     prelude::*,
 };
 use bevy_vello::{prelude::*, VelloPlugin};
-use typst_element::prelude::*;
+use typst::visualize;
+use typst_element::{elem::ContentExt, prelude::*, UnitExt};
 
 fn main() {
     App::new()
@@ -19,16 +20,19 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
-    commands.spawn((VelloAssetBundle {
-        vector: asset_server.load("simple_ui.typ"),
-        ..default()
-    },));
+    // commands.spawn((VelloAssetBundle {
+    //     vector: asset_server.load("simple_ui.typ"),
+    //     ..default()
+    // },));
 
-    commands.spawn(VelloSceneBundle::default());
+    commands.spawn(VelloSceneBundle {
+        coordinate_space: CoordinateSpace::ScreenSpace,
+        ..default()
+    });
 }
 
 fn ui_update(
-    mut q_scene: Query<(&mut VelloScene, &mut Transform)>,
+    mut q_scene: Query<&mut VelloScene>,
     q_window: Query<&Window, With<PrimaryWindow>>,
     world: Res<TypstCompiler>,
     time: Res<Time>,
@@ -44,28 +48,96 @@ fn ui_update(
         return;
     }
 
-    let Ok((mut scene, mut transform)) = q_scene.get_single_mut() else {
+    let Ok(mut scene) = q_scene.get_single_mut() else {
         return;
     };
 
+    let gradient = visualize::Gradient::Linear(std::sync::Arc::new(visualize::LinearGradient {
+        stops: vec![],
+        angle: layout::Angle::zero(),
+        space: visualize::ColorSpace::Srgb,
+        relative: Smart::Auto,
+        anti_alias: true,
+    }));
+
     let mut writer = SimpleWriter::new();
 
-    writer.blank_page(width, height, |writer| {
+    writer.blank_page(|writer| {
         writer.add_content(
-            align(sequence!(
+            sequence!(
                 heading(text(time.elapsed_seconds().to_string())),
                 text((1.0 / time.delta_seconds()).to_string())
-            ))
-            .with_alignment(layout::Alignment::Both(
+            )
+            .align(layout::Alignment::Both(
                 layout::HAlignment::Center,
                 layout::VAlignment::Horizon,
             )),
         );
     });
 
-    let document = world.compile_content(writer.pack()).unwrap();
+    let content = writer
+        .pack()
+        .styled(text::TextElem::set_fill(visualize::Paint::Solid(
+            visualize::Color::WHITE,
+        )))
+        .styled(text::TextElem::set_size(text::TextSize(
+            Abs::pt(24.0).length(),
+        )));
+
+    let document = world.compile_content(content).unwrap();
     let typst_scene = TypstScene::from_document(&document, Abs::zero()).unwrap();
 
-    *transform = Transform::from_xyz(-typst_scene.width * 0.5, typst_scene.height * 0.5, 0.0);
     *scene = typst_scene.as_component();
+}
+
+// pub struct UiWriter<'w, 's>(Vec<Content>, Commands<'w, 's>);
+pub struct UiWriter(Vec<Content>);
+
+impl DocWriter for UiWriter {
+    fn contents(&self) -> &Vec<Content> {
+        &self.0
+    }
+
+    fn contents_mut(&mut self) -> &mut Vec<Content> {
+        &mut self.0
+    }
+
+    fn take_contents(self) -> Vec<Content> {
+        self.0
+    }
+}
+
+impl UiWriter {
+    // pub fn commands(&mut self) -> Commands {
+    //     self.1.reborrow()
+    // }
+}
+
+#[derive(Bundle, Clone, Debug, Default)]
+pub struct EmptyNodeBundle {
+    /// Describes the logical size of the node
+    pub node: Node,
+    /// Styles which control the layout (size and position) of the node and its children
+    /// In some cases these styles also affect how the node drawn/painted.
+    pub style: Style,
+    /// Whether this node should block interaction with lower nodes
+    pub focus_policy: FocusPolicy,
+    /// The transform of the node
+    ///
+    /// This component is automatically managed by the UI layout system.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
+    pub transform: Transform,
+    /// The global transform of the node
+    ///
+    /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
+    pub global_transform: GlobalTransform,
+    /// Describes the visibility properties of the node
+    pub visibility: Visibility,
+    /// Inherited visibility of an entity.
+    pub inherited_visibility: InheritedVisibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub view_visibility: ViewVisibility,
+    /// Indicates the depth at which the node should appear in the UI
+    pub z_index: ZIndex,
 }

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -1,6 +1,18 @@
-use bevy::prelude::*;
-use bevy_typst::prelude::*;
-use bevy_vello::{VelloAssetBundle, VelloPlugin};
+use bevy::{prelude::*, window::PrimaryWindow};
+use bevy_typst::{
+    compiler::{TypstCompiler, TypstScene},
+    prelude::*,
+};
+use bevy_vello::{VelloAssetBundle, VelloPlugin, VelloScene, VelloSceneBundle};
+use typst::{
+    foundations::{Content, FromValue, NativeElement, SequenceElem, Smart},
+    layout::{
+        Abs, AlignElem, Alignment, BlockElem, BoxElem, HAlignment, Length, Margin, PageElem, Ratio,
+        Rel, VAlignment,
+    },
+    model::HeadingElem,
+    text::TextElem,
+};
 
 fn main() {
     App::new()
@@ -9,13 +21,67 @@ fn main() {
         // Custom plugins
         .add_plugins((TypstPlugin::default(), VelloPlugin))
         .add_systems(Startup, setup)
+        .add_systems(Update, ui_update)
         .run();
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
-    commands.spawn((VelloAssetBundle {
-        vector: asset_server.load("simple_ui.typ"),
-        ..default()
-    },));
+    // commands.spawn((VelloAssetBundle {
+    //     vector: asset_server.load("simple_ui.typ"),
+    //     ..default()
+    // },));
+
+    commands.spawn(VelloSceneBundle::default());
+}
+
+fn ui_update(
+    mut q_scene: Query<(&mut VelloScene, &mut Transform)>,
+    q_window: Query<&Window, With<PrimaryWindow>>,
+    world: Res<TypstCompiler>,
+    time: Res<Time>,
+) {
+    let Ok(window) = q_window.get_single() else {
+        return;
+    };
+
+    let width = window.width() as f64 / 1.3333334;
+    let height = window.height() as f64 / 1.3333334;
+
+    println!("width: {width}, height: {height}");
+
+    let Ok((mut scene, mut transform)) = q_scene.get_single_mut() else {
+        return;
+    };
+
+    let content = PageElem::new(
+        SequenceElem::new(vec![
+            HeadingElem::new(TextElem::new(time.elapsed_seconds().to_string().into()).pack())
+                .pack(),
+            TextElem::new((1.0 / time.delta_seconds()).to_string().into()).pack(),
+        ])
+        .pack(),
+    )
+    .with_width(Smart::Custom(Length::from(Abs::pt(width))))
+    .with_height(Smart::Custom(Length::from(Abs::pt(height))))
+    .with_margin(Margin::splat(Some(Smart::Custom(Rel::zero()))))
+    .pack()
+    .styled(AlignElem::set_alignment(Alignment::Both(
+        HAlignment::Center,
+        VAlignment::Horizon,
+    )));
+
+    let mut document = world.compile_content(content).unwrap();
+    let frame = std::mem::take(&mut document.pages[0].frame);
+    // println!("{:?}", frame.width().to_raw());
+    document.pages[0].frame = frame.mark_box();
+    let typst_scene = TypstScene::from_document(&document, Abs::zero()).unwrap();
+
+    println!(
+        "scene: width: {}, height: {}",
+        typst_scene.width, typst_scene.height
+    );
+
+    *transform = Transform::from_xyz(-typst_scene.width * 0.5, typst_scene.height * 0.5, 0.0);
+    *scene = typst_scene.as_component();
 }

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -5,7 +5,7 @@ use bevy_typst::{
 };
 use bevy_vello::{prelude::*, VelloPlugin};
 use typst::visualize;
-use typst_element::{elem::ContentExt, prelude::*, UnitExt};
+use typst_element::{prelude::*, UnitExt};
 
 fn main() {
     App::new()
@@ -52,14 +52,6 @@ fn ui_update(
         return;
     };
 
-    let gradient = visualize::Gradient::Linear(std::sync::Arc::new(visualize::LinearGradient {
-        stops: vec![],
-        angle: layout::Angle::zero(),
-        space: visualize::ColorSpace::Srgb,
-        relative: Smart::Auto,
-        anti_alias: true,
-    }));
-
     let mut writer = SimpleWriter::new();
 
     writer.blank_page(|writer| {
@@ -68,7 +60,8 @@ fn ui_update(
                 heading(text(time.elapsed_seconds().to_string())),
                 text((1.0 / time.delta_seconds()).to_string())
             )
-            .align(layout::Alignment::Both(
+            .pack()
+            .aligned(layout::Alignment::Both(
                 layout::HAlignment::Center,
                 layout::VAlignment::Horizon,
             )),
@@ -83,6 +76,9 @@ fn ui_update(
         .styled(text::TextElem::set_size(text::TextSize(
             Abs::pt(24.0).length(),
         )));
+
+    // content.query()
+    // layout::PageElem::set_binding(Smart::Custom(layout::Binding::Left));
 
     let document = world.compile_content(content).unwrap();
     let typst_scene = TypstScene::from_document(&document, Abs::zero()).unwrap();

--- a/examples/simple_ui.rs
+++ b/examples/simple_ui.rs
@@ -3,12 +3,8 @@ use bevy_typst::{
     compiler::{TypstCompiler, TypstScene},
     prelude::*,
 };
-use bevy_vello::{VelloPlugin, VelloScene, VelloSceneBundle};
-use typst::{
-    foundations::{Content, NativeElement, SequenceElem, Smart, Style},
-    layout::{self, Abs},
-};
-use typst_element::{align, block, heading, page, scale, sequence, text};
+use bevy_vello::{prelude::*, VelloPlugin};
+use typst_element::prelude::*;
 
 fn main() {
     App::new()
@@ -23,10 +19,10 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
-    // commands.spawn((VelloAssetBundle {
-    //     vector: asset_server.load("simple_ui.typ"),
-    //     ..default()
-    // },));
+    commands.spawn((VelloAssetBundle {
+        vector: asset_server.load("simple_ui.typ"),
+        ..default()
+    },));
 
     commands.spawn(VelloSceneBundle::default());
 }
@@ -44,178 +40,32 @@ fn ui_update(
     let width = window.width() as f64;
     let height = window.height() as f64;
 
-    println!("width: {width}, height: {height}");
+    if width <= 0.0 || height <= 0.0 {
+        return;
+    }
 
     let Ok((mut scene, mut transform)) = q_scene.get_single_mut() else {
         return;
     };
 
-    fn length(pt: f64) -> layout::Length {
-        layout::Length::from(layout::Abs::pt(pt))
-    }
+    let mut writer = SimpleWriter::new();
 
-    let content = align(
-        page(
-            scale(
-                block()
-                    .with_width(Smart::Custom(layout::Rel::new(
-                        layout::Ratio::zero(),
-                        length(width),
-                    )))
-                    .with_height(Smart::Custom(layout::Rel::new(
-                        layout::Ratio::zero(),
-                        length(height),
-                    )))
-                    .with_body(Some(
-                        sequence!(
-                            heading(text(time.elapsed_seconds().to_string())),
-                            text((1.0 / time.delta_seconds()).to_string())
-                        )
-                        .pack(),
-                    )),
-            )
-            .with_x(layout::Ratio::new(0.75))
-            .with_y(layout::Ratio::new(0.75))
-            .with_reflow(true),
-        )
-        .with_width(Smart::Auto)
-        .with_height(Smart::Auto)
-        .with_margin(layout::Margin::splat(Some(Smart::Custom(
-            layout::Rel::zero(),
-        )))),
-    )
-    .with_alignment(layout::Alignment::Both(
-        layout::HAlignment::Center,
-        layout::VAlignment::Horizon,
-    ))
-    .pack();
+    writer.blank_page(width, height, |writer| {
+        writer.add_content(
+            align(sequence!(
+                heading(text(time.elapsed_seconds().to_string())),
+                text((1.0 / time.delta_seconds()).to_string())
+            ))
+            .with_alignment(layout::Alignment::Both(
+                layout::HAlignment::Center,
+                layout::VAlignment::Horizon,
+            )),
+        );
+    });
 
-    let mut document = world.compile_content(content).unwrap();
-    let frame = std::mem::take(&mut document.pages[0].frame);
-    document.pages[0].frame = frame.mark_box();
+    let document = world.compile_content(writer.pack()).unwrap();
     let typst_scene = TypstScene::from_document(&document, Abs::zero()).unwrap();
-
-    println!(
-        "scene: width: {}, height: {}",
-        typst_scene.width, typst_scene.height
-    );
 
     *transform = Transform::from_xyz(-typst_scene.width * 0.5, typst_scene.height * 0.5, 0.0);
     *scene = typst_scene.as_component();
-}
-
-#[derive(Default)]
-pub struct TypstBuidler(pub Vec<Content>);
-
-impl TypstBuidler {
-    pub fn add_content(&mut self, content: Content) -> &mut Content {
-        self.0.push(content);
-        self.0.last_mut().unwrap()
-    }
-
-    pub fn pack(self) -> Content {
-        SequenceElem::new(self.0).pack()
-    }
-}
-
-impl TypstBuidler {
-    pub fn new(children: Vec<Content>) -> Self {
-        Self(children)
-    }
-
-    // pub fn page(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
-    //     let mut builder = Self::default();
-    //     builder_fn(&mut builder);
-
-    //     let content = PageElem::new(builder.pack()).pack();
-    //     ContentMut(self.add_content(content))
-    // }
-
-    // pub fn text(&mut self, text: impl Into<EcoString>) -> ContentMut {
-    //     let content = TextElem::new(text.into()).pack();
-    //     ContentMut(self.add_content(content))
-    // }
-
-    // // pub fn quote(&mut self, builder_fn: impl Fn(&mut SequenceBuidler)) -> ContentMut {
-    // //     let mut builder = Self::default();
-    // //     builder_fn(&mut builder);
-
-    // //     let content = QuoteElem::new(builder.pack()).pack();
-    // //     ContentMut(self.add_content(content))
-    // // }
-
-    // pub fn heading(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
-    //     let mut builder = Self::default();
-    //     builder_fn(&mut builder);
-
-    //     let content = HeadingElem::new(builder.pack()).pack();
-    //     ContentMut(self.add_content(content))
-    // }
-
-    // // pub fn boxed(&mut self, builder_fn: impl Fn(&mut SequenceBuidler)) -> ContentMut {
-    // //     let mut builder = Self::default();
-    // //     builder_fn(&mut builder);
-
-    // //     let mut content = BoxElem::new().with_body();
-    // //     let content = BoxElem::new(builder.pack()).pack();
-    // //     ContentMut(self.add_content(content))
-    // // }
-
-    // pub fn par(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
-    //     let mut builder = Self::default();
-    //     builder_fn(&mut builder);
-
-    //     let content = ParElem::new(builder.0).pack();
-    //     ContentMut(self.add_content(content))
-    // }
-
-    // pub fn linebreak(&mut self) -> ContentMut {
-    //     let content = LinebreakElem::new().pack();
-    //     ContentMut(self.add_content(content))
-    // }
-
-    // pub fn parbreak(&mut self) -> ContentMut {
-    //     let content = ParbreakElem::new().pack();
-    //     ContentMut(self.add_content(content))
-    // }
-
-    // pub fn bullet_list(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
-    //     let mut builder = Self::default();
-    //     builder_fn(&mut builder);
-
-    //     let content = ListElem::new(
-    //         builder
-    //             .0
-    //             .drain(..)
-    //             .map(|c| Packed::new(ListItem::new(c)))
-    //             .collect(),
-    //     )
-    //     .pack();
-    //     ContentMut(self.add_content(content))
-    // }
-
-    // pub fn numbered_list(&mut self, builder_fn: impl Fn(&mut TypstBuidler)) -> ContentMut {
-    //     let mut builder = Self::default();
-    //     builder_fn(&mut builder);
-
-    //     let content = EnumElem::new(
-    //         builder
-    //             .0
-    //             .drain(..)
-    //             .map(|c| Packed::new(EnumItem::new(c)))
-    //             .collect(),
-    //     )
-    //     .pack();
-    //     ContentMut(self.add_content(content))
-    // }
-}
-
-pub struct ContentMut<'a>(&'a mut Content);
-
-impl<'a> ContentMut<'a> {
-    pub fn style(self, style: impl Into<Style>) -> Self {
-        let content_value = std::mem::take(self.0);
-        *self.0 = content_value.styled(style);
-        self
-    }
 }

--- a/src/asset/svg_asset.rs
+++ b/src/asset/svg_asset.rs
@@ -51,7 +51,7 @@ impl AssetLoader for SvgAssetLoader {
             .map_err(|_| SvgAssetLoaderError::LoadDirectError)?
             .take();
 
-        let svg_str = typst_svg::svg_merged(typst_asset.document(), Abs::raw(settings.padding));
+        let svg_str = typst_svg::svg_merged(typst_asset.document(), Abs::pt(settings.padding));
         let tree = usvg::Tree::from_str(&svg_str, &usvg::Options::default())?;
 
         Ok(SvgAsset(tree))
@@ -64,6 +64,7 @@ impl AssetLoader for SvgAssetLoader {
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct SvgAssetLoaderSettings {
+    /// Padding around the document (in [`Abs::pt()`]).
     pub padding: f64,
 }
 

--- a/src/asset/svg_asset.rs
+++ b/src/asset/svg_asset.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use typst::layout::Abs;
 
-use crate::prelude::TypstAsset;
+use crate::prelude::TypstDocAsset;
 
 pub struct SvgAssetPlugin;
 
@@ -46,7 +46,7 @@ impl AssetLoader for SvgAssetLoader {
         let asset_path = load_context.asset_path().clone();
         let direct_loader = load_context.loader().direct();
         let typst_asset = direct_loader
-            .load::<TypstAsset>(asset_path)
+            .load::<TypstDocAsset>(asset_path)
             .await
             .map_err(|_| SvgAssetLoaderError::LoadDirectError)?
             .take();

--- a/src/asset/typst_asset.rs
+++ b/src/asset/typst_asset.rs
@@ -6,7 +6,7 @@ use bevy::{
 };
 use ecow::EcoVec;
 use thiserror::Error;
-use typst::{diag::SourceDiagnostic, model::Document};
+use typst::{diag::SourceDiagnostic, foundations::Module, model::Document};
 
 use crate::compiler::world::TypstWorldMeta;
 
@@ -14,28 +14,26 @@ pub struct TypstAssetPlugin(pub Arc<TypstWorldMeta>);
 
 impl Plugin for TypstAssetPlugin {
     fn build(&self, app: &mut App) {
-        app.init_asset::<TypstAsset>()
-            .register_asset_loader(TypstAssetLoader {
-                world_meta: self.0.clone(),
-            });
+        app.init_asset::<TypstDocAsset>()
+            .register_asset_loader(TypstDocAssetLoader(self.0.clone()))
+            .init_asset::<TypstModAsset>()
+            .register_asset_loader(TypstModAssetLoader(self.0.clone()));
     }
 }
 
 #[derive(Asset, TypePath)]
-pub struct TypstAsset(Document);
+pub struct TypstModAsset(Module);
 
-impl TypstAsset {
-    pub fn document(&self) -> &Document {
+impl TypstModAsset {
+    pub fn module(&self) -> &Module {
         &self.0
     }
 }
 
-pub struct TypstAssetLoader {
-    world_meta: Arc<TypstWorldMeta>,
-}
+pub struct TypstModAssetLoader(Arc<TypstWorldMeta>);
 
-impl AssetLoader for TypstAssetLoader {
-    type Asset = TypstAsset;
+impl AssetLoader for TypstModAssetLoader {
+    type Asset = TypstModAsset;
 
     type Settings = ();
 
@@ -50,12 +48,8 @@ impl AssetLoader for TypstAssetLoader {
         let mut text = String::new();
         reader.read_to_string(&mut text).await?;
 
-        let document = self
-            .world_meta
-            .compile_str(&text)
-            .map_err(TypstCompileError)?;
-
-        Ok(TypstAsset(document))
+        let module = self.0.eval_str(&text).map_err(SourceDiagnosticError)?;
+        Ok(TypstModAsset(module))
     }
 
     fn extensions(&self) -> &[&str] {
@@ -63,7 +57,43 @@ impl AssetLoader for TypstAssetLoader {
     }
 }
 
-/// Possible errors that can be produced by [`TypstAssetLoader`].
+#[derive(Asset, TypePath)]
+pub struct TypstDocAsset(Document);
+
+impl TypstDocAsset {
+    pub fn document(&self) -> &Document {
+        &self.0
+    }
+}
+
+pub struct TypstDocAssetLoader(Arc<TypstWorldMeta>);
+
+impl AssetLoader for TypstDocAssetLoader {
+    type Asset = TypstDocAsset;
+
+    type Settings = ();
+
+    type Error = TypstAssetLoaderError;
+
+    async fn load<'a>(
+        &'a self,
+        reader: &'a mut Reader<'_>,
+        _settings: &'a Self::Settings,
+        _load_context: &'a mut LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let mut text = String::new();
+        reader.read_to_string(&mut text).await?;
+
+        let document = self.0.compile_str(&text).map_err(SourceDiagnosticError)?;
+        Ok(TypstDocAsset(document))
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["typ"]
+    }
+}
+
+/// Possible errors that can be produced by [`TypstDocAssetLoader`] and [`TypstModAssetLoader`].
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum TypstAssetLoaderError {
@@ -71,15 +101,15 @@ pub enum TypstAssetLoaderError {
     #[error("Could not load typst file: {0}")]
     Io(#[from] std::io::Error),
 
-    /// A [`typst::compile`] Error
+    /// [SourceDiagnostic] Error
     #[error("Could not compile typst file: {0}")]
-    TypstCompileError(#[from] TypstCompileError),
+    SourceDiagnosticError(#[from] SourceDiagnosticError),
 }
 
 #[derive(Debug, Error)]
-pub struct TypstCompileError(EcoVec<SourceDiagnostic>);
+pub struct SourceDiagnosticError(EcoVec<SourceDiagnostic>);
 
-impl std::fmt::Display for TypstCompileError {
+impl std::fmt::Display for SourceDiagnosticError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(&self.0, f)
     }

--- a/src/asset/typst_asset.rs
+++ b/src/asset/typst_asset.rs
@@ -10,21 +10,13 @@ use typst::{diag::SourceDiagnostic, model::Document};
 
 use crate::compiler::world::TypstWorldMeta;
 
-pub struct TypstAssetPlugin {
-    world_builder: Arc<TypstWorldMeta>,
-}
-
-impl TypstAssetPlugin {
-    pub fn new(world_builder: Arc<TypstWorldMeta>) -> Self {
-        Self { world_builder }
-    }
-}
+pub struct TypstAssetPlugin(pub Arc<TypstWorldMeta>);
 
 impl Plugin for TypstAssetPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset::<TypstAsset>()
             .register_asset_loader(TypstAssetLoader {
-                world_builder: self.world_builder.clone(),
+                world_meta: self.0.clone(),
             });
     }
 }
@@ -39,7 +31,7 @@ impl TypstAsset {
 }
 
 pub struct TypstAssetLoader {
-    world_builder: Arc<TypstWorldMeta>,
+    world_meta: Arc<TypstWorldMeta>,
 }
 
 impl AssetLoader for TypstAssetLoader {
@@ -59,7 +51,7 @@ impl AssetLoader for TypstAssetLoader {
         reader.read_to_string(&mut text).await?;
 
         let document = self
-            .world_builder
+            .world_meta
             .compile_str(&text)
             .map_err(TypstCompileError)?;
 

--- a/src/asset/vello_asset.rs
+++ b/src/asset/vello_asset.rs
@@ -53,17 +53,9 @@ impl AssetLoader for VelloAssetLoader {
 
         let scene = vello_svg::render_tree(&tree);
 
-        let view_size = tree.size();
-        let view_width = view_size.width();
-        let view_height = view_size.height();
-
-        let image_size = tree.size();
-        let image_width = image_size.width();
-        let image_height = image_size.height();
-
-        // Use ratio to calculate actual width and height
-        let width = view_width * view_width / image_width;
-        let height = view_height * view_height / image_height;
+        let size = tree.size();
+        let width = size.width();
+        let height = size.height();
 
         let local_transform_center = Transform::from_xyz(width * 0.5, -height * 0.5, 0.0);
 

--- a/src/asset/vello_asset.rs
+++ b/src/asset/vello_asset.rs
@@ -6,7 +6,7 @@ use bevy_vello::{integrations::VelloAsset, vello_svg::usvg};
 use thiserror::Error;
 use typst::layout::Abs;
 
-use crate::{compiler::TypstScene, prelude::TypstAsset};
+use crate::{compiler::TypstScene, prelude::TypstDocAsset};
 
 use super::svg_asset::SvgAssetLoaderSettings;
 
@@ -38,7 +38,7 @@ impl AssetLoader for VelloAssetLoader {
         let direct_loader = load_context.loader().direct();
 
         let typst_asset = direct_loader
-            .load::<TypstAsset>(asset_path)
+            .load::<TypstDocAsset>(asset_path)
             .await
             .map_err(|_| VelloAssetLoaderError::LoadDirectError)?
             .take();

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -29,6 +29,7 @@ impl TypstCompiler {
     }
 }
 
+#[derive(Clone)]
 pub struct TypstScene {
     pub scene: vello::Scene,
     pub width: f32,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -7,12 +7,7 @@ use bevy_vello::{
     vello_svg::{self, usvg},
     VelloScene,
 };
-use typst::{
-    diag::SourceResult,
-    foundations::{Content, Module},
-    layout::Abs,
-    model::Document,
-};
+use typst::{layout::Abs, model::Document};
 use world::TypstWorldMeta;
 
 pub mod fonts;
@@ -25,16 +20,12 @@ mod package;
 pub struct TypstCompiler(pub Arc<TypstWorldMeta>);
 
 impl TypstCompiler {
-    pub fn eval_str(&self, text: impl Into<String>) -> SourceResult<Module> {
-        self.0.eval_str(text)
+    pub fn world_meta(&self) -> &Arc<TypstWorldMeta> {
+        &self.0
     }
 
-    pub fn compile_str(&self, text: impl Into<String>) -> SourceResult<Document> {
-        self.0.compile_str(text)
-    }
-
-    pub fn compile_content(&self, content: Content) -> SourceResult<Document> {
-        self.0.compile_content(content)
+    pub fn world_meta_clone(&self) -> Arc<TypstWorldMeta> {
+        self.0.clone()
     }
 }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,6 +1,13 @@
 use std::sync::Arc;
 
 use bevy::prelude::*;
+use bevy_vello::{
+    integrations::{VectorFile, VelloAsset},
+    vello,
+    vello_svg::{self, usvg},
+    VelloScene,
+};
+use typst::{diag::SourceResult, foundations::Content, layout::Abs, model::Document};
 use world::TypstWorldMeta;
 
 pub mod fonts;
@@ -10,6 +17,52 @@ mod download;
 mod package;
 
 #[derive(Resource)]
-pub struct TypstCompiler {
-    pub world_builder: Arc<TypstWorldMeta>,
+pub struct TypstCompiler(pub Arc<TypstWorldMeta>);
+
+impl TypstCompiler {
+    pub fn compile_str(&self, text: impl Into<String>) -> SourceResult<Document> {
+        self.0.compile_str(text)
+    }
+
+    pub fn compile_content(&self, content: Content) -> SourceResult<Document> {
+        self.0.compile_content(content)
+    }
+}
+
+pub struct TypstScene {
+    pub scene: vello::Scene,
+    pub width: f32,
+    pub height: f32,
+}
+
+impl TypstScene {
+    pub fn from_document(document: &Document, padding: Abs) -> Result<Self, usvg::Error> {
+        let svg_str = typst_svg::svg_merged(document, padding);
+
+        let tree = usvg::Tree::from_str(&svg_str, &usvg::Options::default())?;
+        let scene = vello_svg::render_tree(&tree);
+        let size = tree.size();
+
+        Ok(Self {
+            scene,
+            width: size.width(),
+            height: size.height(),
+        })
+    }
+
+    pub fn as_asset(self) -> VelloAsset {
+        let local_transform_center = Transform::from_xyz(self.width * 0.5, -self.height * 0.5, 0.0);
+
+        VelloAsset {
+            file: VectorFile::Svg(Arc::new(self.scene)),
+            local_transform_center,
+            width: self.width,
+            height: self.height,
+            alpha: 1.0,
+        }
+    }
+
+    pub fn as_component(self) -> VelloScene {
+        VelloScene::from(self.scene)
+    }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -7,7 +7,12 @@ use bevy_vello::{
     vello_svg::{self, usvg},
     VelloScene,
 };
-use typst::{diag::SourceResult, foundations::Content, layout::Abs, model::Document};
+use typst::{
+    diag::SourceResult,
+    foundations::{Content, Module},
+    layout::Abs,
+    model::Document,
+};
 use world::TypstWorldMeta;
 
 pub mod fonts;
@@ -20,6 +25,10 @@ mod package;
 pub struct TypstCompiler(pub Arc<TypstWorldMeta>);
 
 impl TypstCompiler {
+    pub fn eval_str(&self, text: impl Into<String>) -> SourceResult<Module> {
+        self.0.eval_str(text)
+    }
+
     pub fn compile_str(&self, text: impl Into<String>) -> SourceResult<Document> {
         self.0.compile_str(text)
     }

--- a/src/compiler/world.rs
+++ b/src/compiler/world.rs
@@ -11,7 +11,7 @@ use typst::{
     diag::{warning, FileError, FileResult, SourceResult},
     engine::{Engine, Route},
     eval::Tracer,
-    foundations::{Bytes, Content, Datetime, StyleChain},
+    foundations::{Bytes, Content, Datetime, Module, StyleChain},
     introspection::{Introspector, Locator},
     layout::LayoutRoot,
     model::Document,
@@ -70,8 +70,22 @@ impl TypstWorldMeta {
         self.world(Source::detached(text))
     }
 
+    pub fn eval_str(&self, text: impl Into<String>) -> SourceResult<Module> {
+        // Typst world
+        let world: &dyn World = &self.world_from_str(text);
+        let mut tracer = Tracer::new();
+
+        // Try to evaluate the source file into a module.
+        typst::eval::eval(
+            world.track(),
+            Route::default().track(),
+            tracer.track_mut(),
+            &world.main(),
+        )
+    }
+
     pub fn compile_str(&self, text: impl Into<String>) -> SourceResult<Document> {
-        // Build typst world
+        // Typst world
         let world = self.world_from_str(text);
         let mut tracer = Tracer::new();
 

--- a/src/compiler/world.rs
+++ b/src/compiler/world.rs
@@ -11,9 +11,7 @@ use typst::{
     diag::{warning, FileError, FileResult, SourceResult},
     engine::{Engine, Route},
     eval::Tracer,
-    foundations::{
-        Bytes, Content, Context, Datetime, FromValue, Func, IntoArgs, Module, StyleChain,
-    },
+    foundations::{Bytes, Content, Datetime, Module, StyleChain},
     introspection::{Introspector, Locator},
     layout::LayoutRoot,
     model::Document,

--- a/src/compiler/world.rs
+++ b/src/compiler/world.rs
@@ -123,20 +123,6 @@ impl TypstWorldMeta {
         scope(&mut engine)
     }
 
-    /// Evalulate a Typst function ([`Func`]) with the given arguments ([`IntoArgs`]).
-    ///
-    /// # Panic
-    ///
-    /// 1. Provided arguments ([`IntoArgs`]) does not match the function parameters.
-    /// 2. Function fails to evaluate the results.
-    /// 3. The expected output type from the function is wrong.
-    pub fn eval_func<T: FromValue>(&self, func: &Func, args: impl IntoArgs) -> T {
-        self.scoped_engine(|engine| func.call(engine, Context::none().track(), args))
-            .unwrap()
-            .cast::<T>()
-            .unwrap()
-    }
-
     // Referenced from: https://github.com/typst/typst/blob/v0.11.1/crates/typst/src/lib.rs#L107-L165
     // TODO: This should be implemented upstreamed (or at least exposed as pub fn)
     /// Compile [`Content`] into a [`Document`].

--- a/src/compiler/world.rs
+++ b/src/compiler/world.rs
@@ -1,7 +1,7 @@
 use std::{
     fs, mem,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Mutex, OnceLock},
 };
 
 use bevy::{prelude::*, utils::HashMap};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,10 @@ impl Plugin for TypstPlugin {
         // Using assets/ as the root path
         let mut assets_path = PathBuf::from(".");
         assets_path.push("assets");
-        let world_builder = Arc::new(TypstWorldMeta::new(assets_path, &self.font_paths));
+        let world_meta = Arc::new(TypstWorldMeta::new(assets_path, &self.font_paths));
 
-        app.add_plugins(TypstAssetPlugin::new(world_builder.clone()))
+        app.add_plugins(TypstAssetPlugin(world_meta.clone()))
             .add_plugins((SvgAssetPlugin, VelloAssetPlugin))
-            .insert_resource(TypstCompiler { world_builder });
+            .insert_resource(TypstCompiler(world_meta));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod prelude {
     pub use crate::{
         asset::{
             svg_asset::{SvgAsset, SvgAssetLoaderSettings},
-            typst_asset::TypstAsset,
+            typst_asset::{TypstDocAsset, TypstModAsset},
         },
         TypstPlugin,
     };


### PR DESCRIPTION
Resolves #1 

# Changelog

- Implemented `foundations`, `layout`, `model`, `text`, `symbols`, `math`, `visualize` element functions.
- Added a new `simple_ui` example to showcase Typst - Rust interoperability.
- Added `UnitExt` for easier Typst math type conversion.
- Added `ScopeExt` for getting variables/templates from Typst scope.